### PR TITLE
feat: add active downloads monitoring

### DIFF
--- a/backend/src/hydra.rs
+++ b/backend/src/hydra.rs
@@ -82,6 +82,46 @@ fn get_leveldb_snapshot() -> Snapshot {
     }
 }
 
+pub fn update_game_steam_shortcut(shop: &str, object_id: &str, steam_shortcut_app_id: u32) -> Result<(), String> {
+    let db_path = dirs::config_dir()
+        .unwrap()
+        .join("hydralauncher")
+        .join("hydra-db");
+
+    let key = format!("!games!{}:{}", shop, object_id);
+
+    let mut db = DB::open(&db_path, Options::default())
+        .map_err(|e| format!("Failed to open LevelDB: {}", e))?;
+
+    let value = db.get(key.as_bytes())
+        .ok_or_else(|| format!("Game not found: {}", key))?;
+
+    let mut game: serde_json::Value = serde_json::from_slice(&value)
+        .map_err(|e| format!("Failed to parse game: {}", e))?;
+
+    game["steamShortcutAppId"] = serde_json::json!(steam_shortcut_app_id);
+
+    // Only set winePrefixPath if the game doesn't already have one
+    if game["winePrefixPath"].is_null() {
+        let home = dirs::home_dir().unwrap();
+        let wine_prefix = home
+            .join(".local/share/Steam/steamapps/compatdata")
+            .join(steam_shortcut_app_id.to_string())
+            .join("pfx");
+        game["winePrefixPath"] = serde_json::json!(wine_prefix.to_str().unwrap());
+    }
+
+    let updated = serde_json::to_vec(&game)
+        .map_err(|e| format!("Failed to serialize game: {}", e))?;
+
+    db.put(key.as_bytes(), &updated)
+        .map_err(|e| format!("Failed to write game: {}", e))?;
+
+    db.close().map_err(|e| format!("Failed to close LevelDB: {}", e))?;
+
+    Ok(())
+}
+
 pub fn delete_download(shop: &str, object_id: &str) -> Result<(), String> {
     let db_path = dirs::config_dir()
         .unwrap()

--- a/backend/src/hydra.rs
+++ b/backend/src/hydra.rs
@@ -55,6 +55,7 @@ struct Game {
     icon_url: Option<String>,
     wine_prefix_path: Option<String>,
     automatic_cloud_sync: Option<bool>,
+    executable_path: Option<String>,
 }
 
 fn get_leveldb_snapshot() -> Snapshot {
@@ -81,6 +82,26 @@ fn get_leveldb_snapshot() -> Snapshot {
     }
 }
 
+pub fn delete_download(shop: &str, object_id: &str) -> Result<(), String> {
+    let db_path = dirs::config_dir()
+        .unwrap()
+        .join("hydralauncher")
+        .join("hydra-db");
+
+    // abstract-level sublevel key format: !<sublevel>!<key>
+    let key = format!("!downloads!{}:{}", shop, object_id);
+
+    let mut db = DB::open(&db_path, Options::default())
+        .map_err(|e| format!("Failed to open LevelDB: {}", e))?;
+
+    db.delete(key.as_bytes())
+        .map_err(|e| format!("Failed to delete key: {}", e))?;
+
+    db.close().map_err(|e| format!("Failed to close LevelDB: {}", e))?;
+
+    Ok(())
+}
+
 pub fn get_auth() -> String {
     let mut snapshot = get_leveldb_snapshot();
 
@@ -92,6 +113,43 @@ pub fn get_auth() -> String {
     snapshot.db.close().unwrap();
 
     auth
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Download {
+    pub shop: String,
+    pub object_id: String,
+    pub folder_name: Option<String>,
+    pub progress: f64,
+    pub bytes_downloaded: f64,
+    pub file_size: Option<f64>,
+    pub status: Option<String>,
+    pub extracting: bool,
+    pub extraction_progress: f64,
+    pub queued: bool,
+}
+
+pub fn get_downloads() -> String {
+    let mut snapshot = get_leveldb_snapshot();
+    let mut iter = snapshot.db.new_iter().unwrap();
+    let mut downloads = Vec::new();
+
+    while let Some((key_bytes, value_bytes)) = iter.next() {
+        let key = String::from_utf8(key_bytes).unwrap();
+        if key.starts_with("!downloads") {
+            let raw = String::from_utf8(value_bytes).unwrap();
+            if let Ok(download) = serde_json::from_str::<Download>(&raw) {
+                let status = download.status.as_deref();
+                if !matches!(status, Some("removed")) {
+                    downloads.push(download);
+                }
+            }
+        }
+    }
+
+    snapshot.db.close().unwrap();
+    serde_json::to_string(&downloads).unwrap()
 }
 
 pub fn get_library() -> String {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,5 @@
 use ludusavi::{get_backup_preview, check_if_ludusavi_binary_exists};
-use hydra::{get_auth, get_library, upload_save_game, download_game_artifact};
+use hydra::{get_auth, get_library, get_downloads, delete_download, upload_save_game, download_game_artifact};
 
 mod ludusavi;
 mod hydra;
@@ -16,6 +16,21 @@ async fn main() {
         "get-library" => {
             let library = get_library();
             println!("{}", library);
+        }
+        "get-downloads" => {
+            let downloads = get_downloads();
+            println!("{}", downloads);
+        }
+        "delete-download" => {
+            let shop = std::env::args().nth(2).expect("no shop given");
+            let object_id = std::env::args().nth(3).expect("no object_id given");
+            match delete_download(&shop, &object_id) {
+                Ok(_) => println!("ok"),
+                Err(e) => {
+                    eprintln!("{}", e);
+                    std::process::exit(1);
+                }
+            }
         }
         "get-backup-preview" => {
             let object_id = std::env::args().nth(2).expect("no object id given");

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,5 @@
 use ludusavi::{get_backup_preview, check_if_ludusavi_binary_exists};
-use hydra::{get_auth, get_library, get_downloads, delete_download, upload_save_game, download_game_artifact};
+use hydra::{get_auth, get_library, get_downloads, delete_download, update_game_steam_shortcut, upload_save_game, download_game_artifact};
 
 mod ludusavi;
 mod hydra;
@@ -20,6 +20,18 @@ async fn main() {
         "get-downloads" => {
             let downloads = get_downloads();
             println!("{}", downloads);
+        }
+        "update-game-steam-shortcut" => {
+            let shop = std::env::args().nth(2).expect("no shop given");
+            let object_id = std::env::args().nth(3).expect("no object_id given");
+            let app_id: u32 = std::env::args().nth(4).expect("no app_id given").parse().expect("invalid app_id");
+            match update_game_steam_shortcut(&shop, &object_id, app_id) {
+                Ok(_) => println!("ok"),
+                Err(e) => {
+                    eprintln!("{}", e);
+                    std::process::exit(1);
+                }
+            }
         }
         "delete-download" => {
             let shop = std::env::args().nth(2).expect("no shop given");

--- a/main.py
+++ b/main.py
@@ -11,11 +11,25 @@ class Plugin:
     async def get_auth(self):
         result = subprocess.run([BACKEND_PATH, "get-auth"], capture_output=True, text=True, check=True)
         return json.loads(result.stdout)
-    
+
     async def get_library(self):
         result = subprocess.run([BACKEND_PATH, "get-library"], capture_output=True, text=True, check=True)
         return json.loads(result.stdout)
-    
+
+    async def get_downloads(self):
+        try:
+            result = subprocess.run(
+                [BACKEND_PATH, "get-downloads"],
+                capture_output=True, text=True, check=True, timeout=5
+            )
+            return json.loads(result.stdout)
+        except subprocess.TimeoutExpired:
+            decky.logger.error("get_downloads timed out")
+            return []
+        except Exception as e:
+            decky.logger.error(f"get_downloads failed: {e}")
+            return []
+
     async def backup_and_upload(self, object_id: str, wine_prefix: str, access_token: str, label: str):
         subprocess.run([BACKEND_PATH, "backup-and-upload", object_id, wine_prefix, access_token, label], capture_output=True, text=True, check=True)
 
@@ -25,6 +39,187 @@ class Plugin:
     async def check_if_ludusavi_binary_exists(self):
         result = subprocess.run([BACKEND_PATH, "check-if-ludusavi-binary-exists"], capture_output=True, text=True, check=True)
         return result.stdout.strip() == "true"
+
+    async def launch_hydra_background(self):
+        home = os.path.expanduser("~")
+        decky.logger.info(f"[Hydra] Searching for executable, home={home}")
+
+        try:
+            # Step 1 — fast: known fixed paths (no filesystem scan)
+            fast_candidates = [
+                f"{home}/AppImages/hydra.AppImage",
+                f"{home}/Applications/hydra.AppImage",
+                f"{home}/.local/bin/hydra",
+                "/usr/bin/hydra",
+                "/usr/local/bin/hydra",
+                "/opt/hydra/hydra",
+            ]
+            for path in fast_candidates:
+                if os.path.isfile(path) and os.access(path, os.X_OK):
+                    decky.logger.info(f"[Hydra] Found (fast): {path}")
+                    return self._start_hydra(path)
+
+            # Step 2 — shallow: case-insensitive find in common dirs, 5s timeout each
+            common_dirs = [
+                f"{home}/AppImages",
+                f"{home}/Applications",
+                f"{home}/.local/bin",
+                f"{home}/Downloads",
+                home,
+                "/opt",
+            ]
+            for directory in common_dirs:
+                if not os.path.isdir(directory):
+                    continue
+                try:
+                    result = subprocess.run(
+                        ["find", directory, "-maxdepth", "2", "-iname", "hydra.appimage",
+                         "-o", "-maxdepth", "2", "-iname", "hydra"],
+                        capture_output=True, text=True, timeout=5
+                    )
+                    for line in result.stdout.strip().splitlines():
+                        path = line.strip()
+                        if path and os.path.isfile(path) and os.access(path, os.X_OK):
+                            decky.logger.info(f"[Hydra] Found (shallow): {path}")
+                            return self._start_hydra(path)
+                except subprocess.TimeoutExpired:
+                    decky.logger.warning(f"[Hydra] Shallow search timed out in {directory}")
+
+            # Step 3 — deep: recursive, hard cap at 20s
+            decky.logger.info("[Hydra] Starting deep search (20s timeout)…")
+            try:
+                result = subprocess.run(
+                    ["find", home, "-iname", "hydra.appimage", "-o", "-iname", "hydra"],
+                    capture_output=True, text=True, timeout=20
+                )
+                for line in result.stdout.strip().splitlines():
+                    path = line.strip()
+                    if path and os.path.isfile(path) and os.access(path, os.X_OK):
+                        decky.logger.info(f"[Hydra] Found (deep): {path}")
+                        return self._start_hydra(path)
+            except subprocess.TimeoutExpired:
+                decky.logger.warning("[Hydra] Deep search timed out after 20s")
+
+            decky.logger.error("[Hydra] Executable not found anywhere")
+            return {"success": False, "error": "Hydra not found. Make sure it is installed."}
+
+        except Exception as e:
+            decky.logger.error(f"[Hydra] launch_hydra_background unexpected error: {e}")
+            return {"success": False, "error": str(e)}
+
+    def _start_hydra(self, executable: str):
+        import time
+
+        log_path = "/tmp/hydra-decky-launch.log"
+        try:
+            env = os.environ.copy()
+
+            # Strip Steam/Decky library paths — they break /bin/bash inside AppImages
+            # (causes "undefined symbol: rl_trim_arg_from_keyseq")
+            for var in ("LD_LIBRARY_PATH", "LD_PRELOAD"):
+                old = env.pop(var, None)
+                if old:
+                    decky.logger.info(f"[Hydra] Stripped {var}={old}")
+
+            # Ensure a display is set — Gamescope uses Wayland
+            if not env.get("DISPLAY") and not env.get("WAYLAND_DISPLAY"):
+                env["DISPLAY"] = ":0"
+                decky.logger.warning("[Hydra] No display env found, forcing DISPLAY=:0")
+
+            decky.logger.info(f"[Hydra] DISPLAY={env.get('DISPLAY')} WAYLAND_DISPLAY={env.get('WAYLAND_DISPLAY')}")
+
+            with open(log_path, "w") as log_file:
+                proc = subprocess.Popen(
+                    [executable, "--hidden"],
+                    stdout=log_file,
+                    stderr=log_file,
+                    start_new_session=True,
+                    env=env,
+                )
+
+            decky.logger.info(f"[Hydra] Process started pid={proc.pid}, log at {log_path}")
+
+            # Wait up to 5s for the lockfile to confirm Hydra actually started
+            lockfile = os.path.join(tempfile.gettempdir(), "hydra-launcher.lock")
+            for _ in range(10):
+                time.sleep(0.5)
+                if os.path.exists(lockfile):
+                    decky.logger.info("[Hydra] Lockfile confirmed — Hydra is running")
+                    return {"success": True, "path": executable}
+
+            # Check if process already died
+            ret = proc.poll()
+            if ret is not None:
+                decky.logger.error(f"[Hydra] Process exited immediately with code {ret}, see {log_path}")
+                try:
+                    with open(log_path) as f:
+                        output = f.read(2000)
+                    decky.logger.error(f"[Hydra] Output: {output}")
+                except Exception:
+                    pass
+                return {"success": False, "error": f"Hydra exited immediately (code {ret}). Check /tmp/hydra-decky-launch.log"}
+
+            decky.logger.warning("[Hydra] Lockfile not found after 5s but process is still running")
+            return {"success": True, "path": executable}
+
+        except Exception as e:
+            decky.logger.error(f"[Hydra] Failed to start {executable}: {e}")
+            return {"success": False, "error": f"Failed to start: {e}"}
+
+    async def dismiss_download(self, shop: str, object_id: str):
+        try:
+            result = subprocess.run(
+                [BACKEND_PATH, "delete-download", shop, object_id],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0:
+                decky.logger.info(f"[Hydra] Deleted download {shop}:{object_id}")
+                return {"success": True}
+            else:
+                error = result.stderr.strip()
+                decky.logger.error(f"[Hydra] delete-download failed: {error}")
+                return {"success": False, "error": error}
+        except Exception as e:
+            decky.logger.error(f"[Hydra] dismiss_download error: {e}")
+            return {"success": False, "error": str(e)}
+
+    async def get_steam_shortcut_exe_paths(self) -> list:
+        """Read shortcuts.vdf for all Steam users and return all exe paths."""
+        from pathlib import Path
+        exe_paths = []
+        userdata = Path(decky.DECKY_USER_HOME) / ".local" / "share" / "Steam" / "userdata"
+        if not userdata.is_dir():
+            return exe_paths
+        for user_dir in userdata.iterdir():
+            if not user_dir.is_dir() or not user_dir.name.isdigit():
+                continue
+            shortcuts_path = user_dir / "config" / "shortcuts.vdf"
+            if not shortcuts_path.is_file():
+                continue
+            try:
+                data = shortcuts_path.read_bytes()
+                i = 0
+                while i < len(data):
+                    if data[i] == 0x01:
+                        j = i + 1
+                        while j < len(data) and data[j] != 0:
+                            j += 1
+                        key = data[i + 1:j].decode("utf-8", errors="ignore").lower()
+                        start = j + 1
+                        end = data.find(b"\x00", start)
+                        if end == -1:
+                            break
+                        if key == "exe":
+                            path = data[start:end].decode("utf-8", errors="ignore").strip('"')
+                            if path:
+                                exe_paths.append(path)
+                                decky.logger.info(f"[Hydra] shortcut exe: {path}")
+                        i = end + 1
+                    else:
+                        i += 1
+            except Exception as e:
+                decky.logger.error(f"[Hydra] Failed to read shortcuts.vdf: {e}")
+        return exe_paths
 
     async def is_hydra_launcher_running(self):
         temp_dir = tempfile.gettempdir()

--- a/main.py
+++ b/main.py
@@ -166,6 +166,19 @@ class Plugin:
             decky.logger.error(f"[Hydra] Failed to start {executable}: {e}")
             return {"success": False, "error": f"Failed to start: {e}"}
 
+    async def update_game_steam_shortcut(self, shop: str, object_id: str, app_id: int):
+        try:
+            args = [BACKEND_PATH, "update-game-steam-shortcut", shop, object_id, str(app_id)]
+            result = subprocess.run(args, capture_output=True, text=True, timeout=5)
+            if result.returncode == 0:
+                return {"success": True}
+            error = result.stderr.strip()
+            decky.logger.error(f"[Hydra] update-game-steam-shortcut failed: {error}")
+            return {"success": False, "error": error}
+        except Exception as e:
+            decky.logger.error(f"[Hydra] update_game_steam_shortcut error: {e}")
+            return {"success": False, "error": str(e)}
+
     async def dismiss_download(self, shop: str, object_id: str):
         try:
             result = subprocess.run(

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -34,6 +34,29 @@ export interface Game {
   shop: "steam";
   winePrefixPath: string | null;
   automaticCloudSync: boolean;
+  executablePath: string | null;
+}
+
+export type DownloadStatus =
+  | "active"
+  | "waiting"
+  | "paused"
+  | "error"
+  | "complete"
+  | "seeding"
+  | "extracting";
+
+export interface Download {
+  shop: string;
+  objectId: string;
+  folderName: string | null;
+  progress: number;
+  bytesDownloaded: number;
+  fileSize: number | null;
+  status: DownloadStatus | null;
+  extracting: boolean;
+  extractionProgress: number;
+  queued: boolean;
 }
 
 export interface User {

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -1,0 +1,15 @@
+import { DialogButton, type DialogButtonProps } from "@decky/ui";
+
+export function Button({ className, ...props }: DialogButtonProps) {
+  return (
+    <>
+      <style>{`
+        .hydra-btn:focus,
+        .hydra-btn:hover {
+          border: 2px solid #fff !important;
+        }
+      `}</style>
+      <DialogButton {...props} className={`hydra-btn${className ? ` ${className}` : ""}`} />
+    </>
+  );
+}

--- a/src/components/download-item.tsx
+++ b/src/components/download-item.tsx
@@ -1,0 +1,69 @@
+import { Focusable, PanelSectionRow } from "@decky/ui";
+import { FaPlus, FaTrash } from "react-icons/fa6";
+import { GameIcon } from "./game-icon";
+import { Button } from "./button";
+import { formatBytes } from "../helpers";
+import type { Download } from "../api-types";
+
+interface DownloadItemProps {
+  download: Download;
+  title: string;
+  iconUrl?: string | null;
+  executablePath?: string | null;
+  speed?: number;
+  onDismiss?: () => void;
+  onAddToSteam?: () => void;
+}
+
+export function DownloadItem({ download: d, title, iconUrl, executablePath, speed, onDismiss, onAddToSteam }: DownloadItemProps) {
+  const progress = d.extracting ? d.extractionProgress : d.progress;
+
+  const statusLabel = d.status === "complete"
+    ? "Complete"
+    : d.extracting
+      ? `Extracting… ${Math.round(d.extractionProgress * 100)}%`
+      : d.status === "active"
+        ? `${Math.round(progress * 100)}% · ${formatBytes(d.bytesDownloaded)}${d.fileSize ? ` / ${formatBytes(d.fileSize)}` : ""}${speed ? ` · ${formatBytes(speed)}/s` : ""}`
+        : d.status === "waiting"
+          ? "Waiting…"
+          : d.status === "paused"
+            ? "Paused"
+            : d.status === "error"
+              ? "Error"
+              : "";
+
+  const showAddToSteam = d.status === "complete" && !!executablePath && !!onAddToSteam;
+  const showDismiss = !!onDismiss;
+
+  return (
+    <PanelSectionRow key={d.objectId}>
+      <div className="download-item">
+        <div className="download-item__header">
+          <GameIcon src={iconUrl} alt={title} size={30} />
+          <span className="download-item__title">{title}</span>
+          {(showAddToSteam || showDismiss) && (
+            <Focusable className="download-item__actions" flow-children="horizontal">
+              {showAddToSteam && (
+                <Button style={{ minWidth: "unset", width: 28, height: 28, padding: 0, display: "flex", alignItems: "center", justifyContent: "center" }} onClick={onAddToSteam} title="Add to Steam">
+                  <FaPlus size={12} />
+                </Button>
+              )}
+              {showDismiss && (
+                <Button style={{ minWidth: "unset", width: 28, height: 28, padding: 0, display: "flex", alignItems: "center", justifyContent: "center" }} onClick={onDismiss}>
+                  <FaTrash size={12} />
+                </Button>
+              )}
+            </Focusable>
+          )}
+        </div>
+        <div className="download-item__progress-bar">
+          <div
+            className="download-item__progress-fill"
+            style={{ width: `${Math.round(progress * 100)}%` }}
+          />
+        </div>
+        <span className="download-item__status">{statusLabel}</span>
+      </div>
+    </PanelSectionRow>
+  );
+}

--- a/src/components/downloads-section.tsx
+++ b/src/components/downloads-section.tsx
@@ -3,7 +3,7 @@ import { toaster } from "@decky/api";
 import { useEffect, useRef, useState } from "react";
 import { useLibraryStore } from "../stores";
 import { api } from "../hydra-api";
-import { getDownloads, dismissDownload, getSteamShortcutExePaths } from "../events";
+import { getDownloads, dismissDownload, getSteamShortcutExePaths, updateGameSteamShortcut } from "../events";
 import type { Download, GameAssets, Game } from "../api-types";
 import { DownloadItem } from "./download-item";
 
@@ -116,6 +116,8 @@ export function DownloadsSection() {
     }
 
     setSteamShortcutPaths((prev) => new Set([...prev, executablePath]));
+
+    updateGameSteamShortcut(d.shop, d.objectId, appId).catch(() => {});
 
     if (assets && appId) {
       const artworkPairs: [string | null | undefined, number][] = [

--- a/src/components/downloads-section.tsx
+++ b/src/components/downloads-section.tsx
@@ -1,0 +1,178 @@
+import { PanelSection, PanelSectionRow } from "@decky/ui";
+import { toaster } from "@decky/api";
+import { useEffect, useRef, useState } from "react";
+import { useLibraryStore } from "../stores";
+import { api } from "../hydra-api";
+import { getDownloads, dismissDownload, getSteamShortcutExePaths } from "../events";
+import type { Download, GameAssets, Game } from "../api-types";
+import { DownloadItem } from "./download-item";
+
+const POLL_INTERVAL_S = 3;
+
+async function imageUrlToBase64(url: string): Promise<{ base64: string; ext: "png" | "jpg" } | null> {
+  try {
+    const resp = await fetch(url);
+    const blob = await resp.blob();
+    const ext: "png" | "jpg" = blob.type === "image/png" ? "png" : "jpg";
+    const base64 = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve((reader.result as string).split(",")[1]);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+    return { base64, ext };
+  } catch {
+    return null;
+  }
+}
+
+function resolveGameTitle(download: Download, library: Pick<Game, "objectId" | "title">[]): string {
+  return library.find((g) => g.objectId === download.objectId)?.title
+    ?? download.folderName
+    ?? download.objectId;
+}
+
+export function DownloadsSection() {
+  const { library } = useLibraryStore();
+
+  const [steamShortcutPaths, setSteamShortcutPaths] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [activeDownloads, setActiveDownloads] = useState<Download[]>([]);
+  const [completedDownloads, setCompletedDownloads] = useState<Download[]>([]);
+  const [speeds, setSpeeds] = useState<Map<string, number>>(new Map());
+
+  const prevStatuses = useRef<Map<string, string | null>>(new Map());
+  const prevBytes = useRef<Map<string, number>>(new Map());
+  const isFirstPoll = useRef(true);
+
+  useEffect(() => {
+    getSteamShortcutExePaths()
+      .then((paths) => setSteamShortcutPaths(new Set(paths)))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const poll = async () => {
+      try {
+        const downloads = await getDownloads();
+
+        if (!isFirstPoll.current) {
+          const { library: currentLibrary } = useLibraryStore.getState();
+          for (const d of downloads) {
+            const prev = prevStatuses.current.get(d.objectId);
+            if (d.status === "complete" && prev !== null && prev !== "complete") {
+              toaster.toast({ title: "Download complete", body: resolveGameTitle(d, currentLibrary) });
+            }
+          }
+        }
+
+        const newSpeeds = new Map<string, number>();
+        for (const d of downloads) {
+          const prev = prevBytes.current.get(d.objectId);
+          if (prev !== undefined && d.status === "active") {
+            newSpeeds.set(d.objectId, Math.max(0, d.bytesDownloaded - prev) / POLL_INTERVAL_S);
+          }
+          prevBytes.current.set(d.objectId, d.bytesDownloaded);
+        }
+        setSpeeds(newSpeeds);
+
+        isFirstPoll.current = false;
+        setLoading(false);
+        prevStatuses.current = new Map(downloads.map((d) => [d.objectId, d.status ?? null]));
+
+        setActiveDownloads(
+          downloads.filter((d) => d.status === "active" || d.status === "waiting" || d.status === "paused" || d.status === "error" || d.extracting)
+        );
+        setCompletedDownloads(downloads.filter((d) => d.status === "complete"));
+      } catch (_) {}
+    };
+
+    poll();
+    const interval = setInterval(poll, POLL_INTERVAL_S * 1_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleDismiss = async (download: Download) => {
+    setCompletedDownloads((prev) => prev.filter((d) => d.objectId !== download.objectId));
+    try {
+      const result = await dismissDownload(download.shop, download.objectId);
+      if (!result.success) {
+        setCompletedDownloads((prev) => [...prev, download]);
+        toaster.toast({ title: "Hydra", body: result.error ?? "Could not delete — close Hydra desktop first" });
+      }
+    } catch {
+      setCompletedDownloads((prev) => [...prev, download]);
+    }
+  };
+
+  const handleAddToSteam = async (d: Download, executablePath: string, title: string) => {
+    const [appId, assets] = await Promise.all([
+      SteamClient.Apps.AddShortcut(title, executablePath, "", "") as Promise<number>,
+      api.get<GameAssets | null>(`games/steam/${d.objectId}`).json().catch(() => null),
+    ]);
+
+    if (assets?.title && appId) {
+      SteamClient.Apps.SetShortcutName(appId, assets.title);
+    }
+
+    setSteamShortcutPaths((prev) => new Set([...prev, executablePath]));
+
+    if (assets && appId) {
+      const artworkPairs: [string | null | undefined, number][] = [
+        [assets.coverImageUrl, 0],
+        [assets.libraryHeroImageUrl, 1],
+        [assets.logoImageUrl, 2],
+        [assets.libraryImageUrl, 3],
+      ];
+      for (const [url, assetType] of artworkPairs) {
+        if (!url) continue;
+        const result = await imageUrlToBase64(url);
+        if (result) {
+          await SteamClient.Apps.SetCustomArtworkForApp(appId, result.base64, result.ext, assetType).catch(() => {});
+        }
+      }
+    }
+  };
+
+  return (
+    <PanelSection title="Downloads">
+      {loading ? (
+        <PanelSectionRow>
+          <span className="downloads-placeholder">Loading downloads…</span>
+        </PanelSectionRow>
+      ) : activeDownloads.length === 0 && completedDownloads.length === 0 ? (
+        <PanelSectionRow>
+          <span className="downloads-placeholder">No downloads</span>
+        </PanelSectionRow>
+      ) : (
+        <div className="download-list">
+          {activeDownloads.map((d) => (
+            <DownloadItem
+              key={d.objectId}
+              download={d}
+              title={resolveGameTitle(d, library)}
+              iconUrl={library.find((g) => g.objectId === d.objectId)?.iconUrl}
+              speed={speeds.get(d.objectId)}
+            />
+          ))}
+          {completedDownloads.map((d) => {
+            const game = library.find((g) => g.objectId === d.objectId);
+            const executablePath = game?.executablePath ?? null;
+            const alreadyInSteam = executablePath ? steamShortcutPaths.has(executablePath) : false;
+            return (
+              <DownloadItem
+                key={d.objectId}
+                download={d}
+                title={resolveGameTitle(d, library)}
+                iconUrl={game?.iconUrl}
+                executablePath={alreadyInSteam ? null : executablePath}
+                onDismiss={() => handleDismiss(d)}
+                onAddToSteam={executablePath ? () => handleAddToSteam(d, executablePath, resolveGameTitle(d, library)) : undefined}
+              />
+            );
+          })}
+        </div>
+      )}
+    </PanelSection>
+  );
+}

--- a/src/components/game-icon.tsx
+++ b/src/components/game-icon.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+
+interface GameIconProps {
+  src: string | null | undefined;
+  alt?: string;
+  size?: number;
+}
+
+export function GameIcon({ src, alt = "", size = 30 }: GameIconProps) {
+  const [failed, setFailed] = useState(false);
+
+  if (!src || failed) {
+    return (
+      <div
+        className="game-icon-placeholder"
+        style={{ width: size, height: size, borderRadius: 8, flexShrink: 0 }}
+        title={alt}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          width={size * 0.55}
+          height={size * 0.55}
+        >
+          <rect x="3" y="3" width="18" height="18" rx="2" />
+          <path d="M3 9l4-4 4 4 4-4 4 4" />
+          <circle cx="8.5" cy="14.5" r="1.5" />
+        </svg>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      width={size}
+      height={size}
+      style={{ borderRadius: 8, objectFit: "cover", flexShrink: 0 }}
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,7 @@
 export * from "./hydra-logo";
 export * from "./cloud-icon";
 export * from "./check-icon";
+export * from "./game-icon";
+export * from "./download-item";
+export * from "./downloads-section";
+export * from "./button";

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,12 +1,19 @@
 import { callable } from "@decky/api";
-import type { Game, Auth } from "./api-types";
+import type { Game, Auth, Download } from "./api-types";
 
 export const getAuth = callable<[], Auth>("get_auth");
 export const getLibrary = callable<[], Game[]>("get_library");
+export const getDownloads = callable<[], Download[]>("get_downloads");
 export const backupAndUpload = callable<
   [string, string | null, string, string],
   void
 >("backup_and_upload");
+export const dismissDownload = callable<[string, string], { success: boolean; error?: string }>("dismiss_download");
+export const launchHydraBackground = callable<
+  [],
+  { success: boolean; path?: string; error?: string }
+>("launch_hydra_background");
+export const getSteamShortcutExePaths = callable<[], string[]>("get_steam_shortcut_exe_paths");
 export const isHydraLauncherRunning = callable<[], boolean>(
   "is_hydra_launcher_running"
 );

--- a/src/events.ts
+++ b/src/events.ts
@@ -14,6 +14,7 @@ export const launchHydraBackground = callable<
   { success: boolean; path?: string; error?: string }
 >("launch_hydra_background");
 export const getSteamShortcutExePaths = callable<[], string[]>("get_steam_shortcut_exe_paths");
+export const updateGameSteamShortcut = callable<[string, string, number], { success: boolean; error?: string }>("update_game_steam_shortcut");
 export const isHydraLauncherRunning = callable<[], boolean>(
   "is_hydra_launcher_running"
 );

--- a/src/home.tsx
+++ b/src/home.tsx
@@ -1,5 +1,6 @@
-import { Button, PanelSection, PanelSectionRow } from "@decky/ui";
-import { useCallback, useEffect, useMemo } from "react";
+import { Button, ButtonItem, PanelSection, PanelSectionRow } from "@decky/ui";
+import { toaster } from "@decky/api";
+import { useEffect, useMemo, useState } from "react";
 import {
   useCurrentGame,
   useLibraryStore,
@@ -8,33 +9,83 @@ import {
 } from "./stores";
 import { api } from "./hydra-api";
 import { usePlaytime } from "./hooks";
-import { HydraLogo } from "./components/hydra-logo";
+import { HydraLogo, GameIcon, DownloadsSection } from "./components";
+import { isHydraLauncherRunning, launchHydraBackground } from "./events";
 import type { GameAssets } from "./api-types";
+
+type LaunchState = "idle" | "searching" | "starting";
 
 export function Home() {
   const { user, hasActiveSubscription } = useUserStore();
   const { library } = useLibraryStore();
   const { hours, minutes, seconds } = usePlaytime();
-
   const { setRoute } = useNavigationStore();
+  const { objectId, gameAssets } = useCurrentGame();
 
-  const { objectId, gameAssets, setGameAssets } = useCurrentGame();
+  const [showLaunchButton, setShowLaunchButton] = useState(false);
+  const [launchState, setLaunchState] = useState<LaunchState>("idle");
 
-  const getGameCurrentlyPlaying = useCallback(async () => {
-    const asssets = await api
-      .get<GameAssets | null>(`games/steam/${objectId}`)
-      .json();
-
-    if (asssets) {
-      setGameAssets(asssets);
+  const tryLaunchHydra = async (): Promise<boolean> => {
+    setLaunchState("searching");
+    try {
+      const result = await Promise.race([
+        launchHydraBackground(),
+        new Promise<{ success: false; error: string }>((resolve) =>
+          setTimeout(() => resolve({ success: false, error: "Search timed out after 30s" }), 30_000)
+        ),
+      ]);
+      if (result.success) {
+        setLaunchState("starting");
+        setTimeout(() => setLaunchState("idle"), 3_000);
+        return true;
+      } else {
+        setLaunchState("idle");
+        return false;
+      }
+    } catch {
+      setLaunchState("idle");
+      return false;
     }
-  }, [objectId, setGameAssets]);
+  };
+
+  // Auto-launch on mount if Hydra is not running
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const running = await isHydraLauncherRunning();
+        if (running) { setShowLaunchButton(false); return; }
+        const ok = await tryLaunchHydra();
+        if (!ok) setShowLaunchButton(true);
+      } catch {
+        setShowLaunchButton(true);
+      }
+    };
+    init();
+  }, []);
+
+  // Poll hydra running state every 3s
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      try {
+        const running = await isHydraLauncherRunning();
+        if (running) setShowLaunchButton(false);
+      } catch {}
+    }, 3_000);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
-    if (objectId) {
-      getGameCurrentlyPlaying();
-    }
-  }, [objectId, getGameCurrentlyPlaying]);
+    if (!objectId) return;
+    api.get<GameAssets | null>(`games/steam/${objectId}`)
+      .json()
+      .then((assets) => { if (assets) useCurrentGame.getState().setGameAssets(assets); })
+      .catch(() => {});
+  }, [objectId]);
+
+  const handleManualLaunch = async () => {
+    const ok = await tryLaunchHydra();
+    if (!ok) toaster.toast({ title: "Hydra", body: "Could not find Hydra executable" });
+  };
 
   const playingNowContent = useMemo(() => {
     if (objectId) {
@@ -65,7 +116,6 @@ export function Home() {
         </Button>
       );
     }
-
     return (
       <div className="playtime-description">
         <span>No game session in progress.</span>
@@ -76,6 +126,13 @@ export function Home() {
       </div>
     );
   }, [gameAssets, objectId, hours, minutes, seconds]);
+
+  const launchButtonLabel =
+    launchState === "searching"
+      ? "Searching for Hydra…"
+      : launchState === "starting"
+        ? "Starting Hydra…"
+        : "Run downloads in background";
 
   return (
     <>
@@ -104,14 +161,23 @@ export function Home() {
 
       <PanelSection title="Playing now">{playingNowContent}</PanelSection>
 
+      {showLaunchButton && (
+        <PanelSection title="Hydra">
+          <ButtonItem disabled={launchState !== "idle"} onClick={handleManualLaunch}>
+            {launchButtonLabel}
+          </ButtonItem>
+        </PanelSection>
+      )}
+
+      <DownloadsSection />
+
       <PanelSection title="Playable on the Deck">
         <div className="library-games">
           {library
             .filter((game) => game.winePrefixPath)
             .map((game) => (
-              <PanelSectionRow>
+              <PanelSectionRow key={game.remoteId}>
                 <Button
-                  key={game.remoteId}
                   className="library-game"
                   onClick={() =>
                     setRoute({
@@ -122,12 +188,7 @@ export function Home() {
                     })
                   }
                 >
-                  <img
-                    src={game.iconUrl}
-                    width="30"
-                    style={{ borderRadius: 8, objectFit: "cover" }}
-                    alt={game.title}
-                  />
+                  <GameIcon src={game.iconUrl} alt={game.title} size={30} />
                   <span className="library-game__title">{game.title}</span>
                 </Button>
               </PanelSectionRow>

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -117,6 +117,90 @@
   }
 }
 
+.game-icon-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.3);
+  flex-shrink: 0;
+}
+
+.downloads-placeholder {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.3);
+  display: block;
+  text-align: center;
+  padding: 4px 0;
+}
+
+.download-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.download-item {
+  box-sizing: border-box;
+  width: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background-color: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  padding: 8px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  &__actions {
+    display: flex !important;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+    flex-shrink: 0;
+  }
+
+
+  &__title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #fff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+    flex: 1;
+  }
+
+  &__progress-bar {
+    box-sizing: border-box;
+    width: 100%;
+    height: 4px;
+    background-color: rgba(255, 255, 255, 0.15);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  &__progress-fill {
+    height: 100%;
+    background: linear-gradient(93deg, #0cf1ca 0%, #1dcceb 50%, #134fd0 100%);
+    border-radius: 2px;
+    transition: width 0.5s ease;
+  }
+
+  &__status {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.5);
+  }
+}
+
 .library-games {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
I've added a download display; it shows both current and completed downloads. To do this, I had to configure the plugin to search for the Hydra app image when it launches, and once found, it displays the downloads.

Once downloaded, you have the option to delete the download (not the files themselves). This removes the download entry from both the plugin and Hydra.

Here's an image of what it looks like:

![screenshot 2](https://github.com/user-attachments/assets/85a2ca64-aa6c-433a-b5eb-c5105eba5fbf)


Next, I'd like to:

1- Add a settings tab to choose the format in which to display the download speed, if you agree.

2- Reduce the size of the message if no game is running.

3- Improve navigation by adding a Decky Focusable component so that clicking B doesn't take us out of the plugin when we're in the save game view (currently, pressing B takes us out of the plugin when we're in the save game view).

4- Add translations