### PR TITLE
feat: add Steam emulator username/language editor per game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ cli/*
 cli/decky
 
 backend/target
+
+# Ignore local package.sh zips
+packages/

--- a/backend/src/hydra.rs
+++ b/backend/src/hydra.rs
@@ -82,6 +82,46 @@ fn get_leveldb_snapshot() -> Snapshot {
     }
 }
 
+pub fn update_game_steam_shortcut(shop: &str, object_id: &str, steam_shortcut_app_id: u32) -> Result<(), String> {
+    let db_path = dirs::config_dir()
+        .unwrap()
+        .join("hydralauncher")
+        .join("hydra-db");
+
+    let key = format!("!games!{}:{}", shop, object_id);
+
+    let mut db = DB::open(&db_path, Options::default())
+        .map_err(|e| format!("Failed to open LevelDB: {}", e))?;
+
+    let value = db.get(key.as_bytes())
+        .ok_or_else(|| format!("Game not found: {}", key))?;
+
+    let mut game: serde_json::Value = serde_json::from_slice(&value)
+        .map_err(|e| format!("Failed to parse game: {}", e))?;
+
+    game["steamShortcutAppId"] = serde_json::json!(steam_shortcut_app_id);
+
+    // Only set winePrefixPath if the game doesn't already have one
+    if game["winePrefixPath"].is_null() {
+        let home = dirs::home_dir().unwrap();
+        let wine_prefix = home
+            .join(".local/share/Steam/steamapps/compatdata")
+            .join(steam_shortcut_app_id.to_string())
+            .join("pfx");
+        game["winePrefixPath"] = serde_json::json!(wine_prefix.to_str().unwrap());
+    }
+
+    let updated = serde_json::to_vec(&game)
+        .map_err(|e| format!("Failed to serialize game: {}", e))?;
+
+    db.put(key.as_bytes(), &updated)
+        .map_err(|e| format!("Failed to write game: {}", e))?;
+
+    db.close().map_err(|e| format!("Failed to close LevelDB: {}", e))?;
+
+    Ok(())
+}
+
 pub fn delete_download(shop: &str, object_id: &str) -> Result<(), String> {
     let db_path = dirs::config_dir()
         .unwrap()

--- a/backend/src/hydra.rs
+++ b/backend/src/hydra.rs
@@ -55,6 +55,7 @@ struct Game {
     icon_url: Option<String>,
     wine_prefix_path: Option<String>,
     automatic_cloud_sync: Option<bool>,
+    executable_path: Option<String>,
 }
 
 fn get_leveldb_snapshot() -> Snapshot {
@@ -264,6 +265,36 @@ fn restore_ludusavi_backup(
             fs::rename(source_path, destination_path)?;
         }
     }
+
+    Ok(())
+}
+
+pub fn toggle_automatic_cloud_sync(shop: &str, object_id: &str, automatic_cloud_sync: bool) -> Result<(), String> {
+    let db_path = dirs::config_dir()
+        .unwrap()
+        .join("hydralauncher")
+        .join("hydra-db");
+
+    let key = format!("!games!{}:{}", shop, object_id);
+
+    let mut db = DB::open(&db_path, Options::default())
+        .map_err(|e| format!("Failed to open DB: {:?}", e))?;
+
+    let value = db.get(key.as_bytes())
+        .ok_or_else(|| format!("Game not found: {}", key))?;
+
+    let mut game: serde_json::Value = serde_json::from_slice(&value)
+        .map_err(|e| format!("Failed to parse game: {:?}", e))?;
+
+    game["automaticCloudSync"] = serde_json::json!(automatic_cloud_sync);
+
+    let updated = serde_json::to_vec(&game)
+        .map_err(|e| format!("Failed to serialize game: {:?}", e))?;
+
+    db.put(key.as_bytes(), &updated)
+        .map_err(|e| format!("Failed to write to DB: {:?}", e))?;
+
+    db.close().map_err(|e| format!("Failed to close DB: {:?}", e))?;
 
     Ok(())
 }

--- a/backend/src/hydra.rs
+++ b/backend/src/hydra.rs
@@ -55,6 +55,7 @@ struct Game {
     icon_url: Option<String>,
     wine_prefix_path: Option<String>,
     automatic_cloud_sync: Option<bool>,
+    executable_path: Option<String>,
 }
 
 fn get_leveldb_snapshot() -> Snapshot {
@@ -81,6 +82,26 @@ fn get_leveldb_snapshot() -> Snapshot {
     }
 }
 
+pub fn delete_download(shop: &str, object_id: &str) -> Result<(), String> {
+    let db_path = dirs::config_dir()
+        .unwrap()
+        .join("hydralauncher")
+        .join("hydra-db");
+
+    // abstract-level sublevel key format: !<sublevel>!<key>
+    let key = format!("!downloads!{}:{}", shop, object_id);
+
+    let mut db = DB::open(&db_path, Options::default())
+        .map_err(|e| format!("Failed to open LevelDB: {}", e))?;
+
+    db.delete(key.as_bytes())
+        .map_err(|e| format!("Failed to delete key: {}", e))?;
+
+    db.close().map_err(|e| format!("Failed to close LevelDB: {}", e))?;
+
+    Ok(())
+}
+
 pub fn get_auth() -> String {
     let mut snapshot = get_leveldb_snapshot();
 
@@ -92,6 +113,43 @@ pub fn get_auth() -> String {
     snapshot.db.close().unwrap();
 
     auth
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Download {
+    pub shop: String,
+    pub object_id: String,
+    pub folder_name: Option<String>,
+    pub progress: f64,
+    pub bytes_downloaded: f64,
+    pub file_size: Option<f64>,
+    pub status: Option<String>,
+    pub extracting: bool,
+    pub extraction_progress: f64,
+    pub queued: bool,
+}
+
+pub fn get_downloads() -> String {
+    let mut snapshot = get_leveldb_snapshot();
+    let mut iter = snapshot.db.new_iter().unwrap();
+    let mut downloads = Vec::new();
+
+    while let Some((key_bytes, value_bytes)) = iter.next() {
+        let key = String::from_utf8(key_bytes).unwrap();
+        if key.starts_with("!downloads") {
+            let raw = String::from_utf8(value_bytes).unwrap();
+            if let Ok(download) = serde_json::from_str::<Download>(&raw) {
+                let status = download.status.as_deref();
+                if !matches!(status, Some("removed")) {
+                    downloads.push(download);
+                }
+            }
+        }
+    }
+
+    snapshot.db.close().unwrap();
+    serde_json::to_string(&downloads).unwrap()
 }
 
 pub fn get_library() -> String {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,5 @@
 use ludusavi::{get_backup_preview, check_if_ludusavi_binary_exists};
-use hydra::{get_auth, get_library, upload_save_game, download_game_artifact};
+use hydra::{get_auth, get_library, get_downloads, delete_download, upload_save_game, download_game_artifact};
 
 mod ludusavi;
 mod hydra;
@@ -16,6 +16,21 @@ async fn main() {
         "get-library" => {
             let library = get_library();
             println!("{}", library);
+        }
+        "get-downloads" => {
+            let downloads = get_downloads();
+            println!("{}", downloads);
+        }
+        "delete-download" => {
+            let shop = std::env::args().nth(2).expect("no shop given");
+            let object_id = std::env::args().nth(3).expect("no object_id given");
+            match delete_download(&shop, &object_id) {
+                Ok(_) => println!("ok"),
+                Err(e) => {
+                    eprintln!("{}", e);
+                    std::process::exit(1);
+                }
+            }
         }
         "get-backup-preview" => {
             let object_id = std::env::args().nth(2).expect("no object id given");

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,5 @@
 use ludusavi::{get_backup_preview, check_if_ludusavi_binary_exists};
-use hydra::{get_auth, get_library, get_downloads, delete_download, upload_save_game, download_game_artifact};
+use hydra::{get_auth, get_library, get_downloads, delete_download, update_game_steam_shortcut, upload_save_game, download_game_artifact};
 
 mod ludusavi;
 mod hydra;
@@ -20,6 +20,18 @@ async fn main() {
         "get-downloads" => {
             let downloads = get_downloads();
             println!("{}", downloads);
+        }
+        "update-game-steam-shortcut" => {
+            let shop = std::env::args().nth(2).expect("no shop given");
+            let object_id = std::env::args().nth(3).expect("no object_id given");
+            let app_id: u32 = std::env::args().nth(4).expect("no app_id given").parse().expect("invalid app_id");
+            match update_game_steam_shortcut(&shop, &object_id, app_id) {
+                Ok(_) => println!("ok"),
+                Err(e) => {
+                    eprintln!("{}", e);
+                    std::process::exit(1);
+                }
+            }
         }
         "delete-download" => {
             let shop = std::env::args().nth(2).expect("no shop given");

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,5 @@
 use ludusavi::{get_backup_preview, check_if_ludusavi_binary_exists};
-use hydra::{get_auth, get_library, upload_save_game, download_game_artifact};
+use hydra::{get_auth, get_library, upload_save_game, download_game_artifact, toggle_automatic_cloud_sync};
 
 mod ludusavi;
 mod hydra;
@@ -44,6 +44,12 @@ async fn main() {
         "check-if-ludusavi-binary-exists" => {
             let exists = check_if_ludusavi_binary_exists();
             println!("{}", exists);
+        }
+        "toggle-automatic-cloud-sync" => {
+            let shop = std::env::args().nth(2).expect("no shop given");
+            let object_id = std::env::args().nth(3).expect("no object id given");
+            let automatic_cloud_sync = std::env::args().nth(4).expect("no value given") == "true";
+            toggle_automatic_cloud_sync(&shop, &object_id, automatic_cloud_sync).unwrap();
         }
         _ => {
             println!("Invalid command");

--- a/main.py
+++ b/main.py
@@ -26,6 +26,9 @@ class Plugin:
         result = subprocess.run([BACKEND_PATH, "check-if-ludusavi-binary-exists"], capture_output=True, text=True, check=True)
         return result.stdout.strip() == "true"
 
+    async def toggle_automatic_cloud_sync(self, shop: str, object_id: str, automatic_cloud_sync: bool):
+        subprocess.run([BACKEND_PATH, "toggle-automatic-cloud-sync", shop, object_id, str(automatic_cloud_sync).lower()], capture_output=True, text=True, check=True)
+
     async def is_hydra_launcher_running(self):
         temp_dir = tempfile.gettempdir()
         lockfile = f"{temp_dir}/hydra-launcher.lock"

--- a/main.py
+++ b/main.py
@@ -11,11 +11,25 @@ class Plugin:
     async def get_auth(self):
         result = subprocess.run([BACKEND_PATH, "get-auth"], capture_output=True, text=True, check=True)
         return json.loads(result.stdout)
-    
+
     async def get_library(self):
         result = subprocess.run([BACKEND_PATH, "get-library"], capture_output=True, text=True, check=True)
         return json.loads(result.stdout)
-    
+
+    async def get_downloads(self):
+        try:
+            result = subprocess.run(
+                [BACKEND_PATH, "get-downloads"],
+                capture_output=True, text=True, check=True, timeout=5
+            )
+            return json.loads(result.stdout)
+        except subprocess.TimeoutExpired:
+            decky.logger.error("get_downloads timed out")
+            return []
+        except Exception as e:
+            decky.logger.error(f"get_downloads failed: {e}")
+            return []
+
     async def backup_and_upload(self, object_id: str, wine_prefix: str, access_token: str, label: str):
         subprocess.run([BACKEND_PATH, "backup-and-upload", object_id, wine_prefix, access_token, label], capture_output=True, text=True, check=True)
 
@@ -25,6 +39,187 @@ class Plugin:
     async def check_if_ludusavi_binary_exists(self):
         result = subprocess.run([BACKEND_PATH, "check-if-ludusavi-binary-exists"], capture_output=True, text=True, check=True)
         return result.stdout.strip() == "true"
+
+    async def launch_hydra_background(self):
+        home = os.path.expanduser("~")
+        decky.logger.info(f"[Hydra] Searching for executable, home={home}")
+
+        try:
+            # Step 1 — fast: known fixed paths (no filesystem scan)
+            fast_candidates = [
+                f"{home}/AppImages/hydra.AppImage",
+                f"{home}/Applications/hydra.AppImage",
+                f"{home}/.local/bin/hydra",
+                "/usr/bin/hydra",
+                "/usr/local/bin/hydra",
+                "/opt/hydra/hydra",
+            ]
+            for path in fast_candidates:
+                if os.path.isfile(path) and os.access(path, os.X_OK):
+                    decky.logger.info(f"[Hydra] Found (fast): {path}")
+                    return self._start_hydra(path)
+
+            # Step 2 — shallow: case-insensitive find in common dirs, 5s timeout each
+            common_dirs = [
+                f"{home}/AppImages",
+                f"{home}/Applications",
+                f"{home}/.local/bin",
+                f"{home}/Downloads",
+                home,
+                "/opt",
+            ]
+            for directory in common_dirs:
+                if not os.path.isdir(directory):
+                    continue
+                try:
+                    result = subprocess.run(
+                        ["find", directory, "-maxdepth", "2", "-iname", "hydra.appimage",
+                         "-o", "-maxdepth", "2", "-iname", "hydra"],
+                        capture_output=True, text=True, timeout=5
+                    )
+                    for line in result.stdout.strip().splitlines():
+                        path = line.strip()
+                        if path and os.path.isfile(path) and os.access(path, os.X_OK):
+                            decky.logger.info(f"[Hydra] Found (shallow): {path}")
+                            return self._start_hydra(path)
+                except subprocess.TimeoutExpired:
+                    decky.logger.warning(f"[Hydra] Shallow search timed out in {directory}")
+
+            # Step 3 — deep: recursive, hard cap at 20s
+            decky.logger.info("[Hydra] Starting deep search (20s timeout)…")
+            try:
+                result = subprocess.run(
+                    ["find", home, "-iname", "hydra.appimage", "-o", "-iname", "hydra"],
+                    capture_output=True, text=True, timeout=20
+                )
+                for line in result.stdout.strip().splitlines():
+                    path = line.strip()
+                    if path and os.path.isfile(path) and os.access(path, os.X_OK):
+                        decky.logger.info(f"[Hydra] Found (deep): {path}")
+                        return self._start_hydra(path)
+            except subprocess.TimeoutExpired:
+                decky.logger.warning("[Hydra] Deep search timed out after 20s")
+
+            decky.logger.error("[Hydra] Executable not found anywhere")
+            return {"success": False, "error": "Hydra not found. Make sure it is installed."}
+
+        except Exception as e:
+            decky.logger.error(f"[Hydra] launch_hydra_background unexpected error: {e}")
+            return {"success": False, "error": str(e)}
+
+    def _start_hydra(self, executable: str):
+        import time
+
+        log_path = "/tmp/hydra-decky-launch.log"
+        try:
+            env = os.environ.copy()
+
+            # Strip Steam/Decky library paths — they break /bin/bash inside AppImages
+            # (causes "undefined symbol: rl_trim_arg_from_keyseq")
+            for var in ("LD_LIBRARY_PATH", "LD_PRELOAD"):
+                old = env.pop(var, None)
+                if old:
+                    decky.logger.info(f"[Hydra] Stripped {var}={old}")
+
+            # Ensure a display is set — Gamescope uses Wayland
+            if not env.get("DISPLAY") and not env.get("WAYLAND_DISPLAY"):
+                env["DISPLAY"] = ":0"
+                decky.logger.warning("[Hydra] No display env found, forcing DISPLAY=:0")
+
+            decky.logger.info(f"[Hydra] DISPLAY={env.get('DISPLAY')} WAYLAND_DISPLAY={env.get('WAYLAND_DISPLAY')}")
+
+            with open(log_path, "w") as log_file:
+                proc = subprocess.Popen(
+                    [executable, "--hidden"],
+                    stdout=log_file,
+                    stderr=log_file,
+                    start_new_session=True,
+                    env=env,
+                )
+
+            decky.logger.info(f"[Hydra] Process started pid={proc.pid}, log at {log_path}")
+
+            # Wait up to 5s for the lockfile to confirm Hydra actually started
+            lockfile = os.path.join(tempfile.gettempdir(), "hydra-launcher.lock")
+            for _ in range(10):
+                time.sleep(0.5)
+                if os.path.exists(lockfile):
+                    decky.logger.info("[Hydra] Lockfile confirmed — Hydra is running")
+                    return {"success": True, "path": executable}
+
+            # Check if process already died
+            ret = proc.poll()
+            if ret is not None:
+                decky.logger.error(f"[Hydra] Process exited immediately with code {ret}, see {log_path}")
+                try:
+                    with open(log_path) as f:
+                        output = f.read(2000)
+                    decky.logger.error(f"[Hydra] Output: {output}")
+                except Exception:
+                    pass
+                return {"success": False, "error": f"Hydra exited immediately (code {ret}). Check /tmp/hydra-decky-launch.log"}
+
+            decky.logger.warning("[Hydra] Lockfile not found after 5s but process is still running")
+            return {"success": True, "path": executable}
+
+        except Exception as e:
+            decky.logger.error(f"[Hydra] Failed to start {executable}: {e}")
+            return {"success": False, "error": f"Failed to start: {e}"}
+
+    async def dismiss_download(self, shop: str, object_id: str):
+        try:
+            result = subprocess.run(
+                [BACKEND_PATH, "delete-download", shop, object_id],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0:
+                decky.logger.info(f"[Hydra] Deleted download {shop}:{object_id}")
+                return {"success": True}
+            else:
+                error = result.stderr.strip()
+                decky.logger.error(f"[Hydra] delete-download failed: {error}")
+                return {"success": False, "error": error}
+        except Exception as e:
+            decky.logger.error(f"[Hydra] dismiss_download error: {e}")
+            return {"success": False, "error": str(e)}
+
+    async def get_steam_shortcut_exe_paths(self) -> list:
+        """Read shortcuts.vdf for all Steam users and return all exe paths."""
+        from pathlib import Path
+        exe_paths = []
+        userdata = Path(decky.DECKY_USER_HOME) / ".local" / "share" / "Steam" / "userdata"
+        if not userdata.is_dir():
+            return exe_paths
+        for user_dir in userdata.iterdir():
+            if not user_dir.is_dir() or not user_dir.name.isdigit():
+                continue
+            shortcuts_path = user_dir / "config" / "shortcuts.vdf"
+            if not shortcuts_path.is_file():
+                continue
+            try:
+                data = shortcuts_path.read_bytes()
+                i = 0
+                while i < len(data):
+                    if data[i] == 0x01:
+                        j = i + 1
+                        while j < len(data) and data[j] != 0:
+                            j += 1
+                        key = data[i + 1:j].decode("utf-8", errors="ignore").lower()
+                        start = j + 1
+                        end = data.find(b"\x00", start)
+                        if end == -1:
+                            break
+                        if key == "exe":
+                            path = data[start:end].decode("utf-8", errors="ignore").strip('"')
+                            if path:
+                                exe_paths.append(path)
+                                decky.logger.info(f"[Hydra] shortcut exe: {path}")
+                        i = end + 1
+                    else:
+                        i += 1
+            except Exception as e:
+                decky.logger.error(f"[Hydra] Failed to read shortcuts.vdf: {e}")
+        return exe_paths
 
     async def is_hydra_launcher_running(self):
         temp_dir = tempfile.gettempdir()

--- a/main.py
+++ b/main.py
@@ -166,6 +166,19 @@ class Plugin:
             decky.logger.error(f"[Hydra] Failed to start {executable}: {e}")
             return {"success": False, "error": f"Failed to start: {e}"}
 
+    async def update_game_steam_shortcut(self, shop: str, object_id: str, app_id: int):
+        try:
+            args = [BACKEND_PATH, "update-game-steam-shortcut", shop, object_id, str(app_id)]
+            result = subprocess.run(args, capture_output=True, text=True, timeout=5)
+            if result.returncode == 0:
+                return {"success": True}
+            error = result.stderr.strip()
+            decky.logger.error(f"[Hydra] update-game-steam-shortcut failed: {error}")
+            return {"success": False, "error": error}
+        except Exception as e:
+            decky.logger.error(f"[Hydra] update_game_steam_shortcut error: {e}")
+            return {"success": False, "error": str(e)}
+
     async def dismiss_download(self, shop: str, object_id: str):
         try:
             result = subprocess.run(

--- a/main.py
+++ b/main.py
@@ -128,15 +128,45 @@ class Plugin:
             decky.logger.error(f"[Hydra] launch_hydra_background unexpected error: {e}")
             return {"success": False, "error": str(e)}
 
+    def _read_gamescope_environment(self, runtime_dir: str):
+        """SteamOS's gamescope (Gaming Mode) session writes its own
+        recommended environment for external apps to $XDG_RUNTIME_DIR/
+        gamescope-environment. It uses plain X11 (DISPLAY=:0, no
+        Xauthority needed) rather than Wayland, so this is the
+        authoritative source instead of guessing a socket name."""
+        env_path = os.path.join(runtime_dir, "gamescope-environment")
+        if not os.path.isfile(env_path):
+            return {}
+
+        wanted_keys = ("DISPLAY", "WAYLAND_DISPLAY", "XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS")
+        overrides = {}
+        try:
+            with open(env_path, "r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    key, _, value = line.strip().partition("=")
+                    if key in wanted_keys and value:
+                        overrides[key] = value
+        except Exception as e:
+            decky.logger.error(f"[Hydra] Failed to read {env_path}: {e}")
+            return {}
+
+        return overrides
+
     def _discover_display_env(self):
-        """Find the desktop session's real Wayland socket (or, failing that,
-        its X11 Xauthority cookie). plugin_loader.service runs with no display
-        env at all, so blindly forcing DISPLAY=:0 fails with "Authorization
-        required, but no authorization protocol specified"."""
+        """Find the desktop session's real display environment.
+        plugin_loader.service runs with no display env at all, so blindly
+        forcing DISPLAY=:0 fails with "Authorization required, but no
+        authorization protocol specified"."""
         runtime_dir = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
         if not os.path.isdir(runtime_dir):
             return {}
 
+        gamescope_env = self._read_gamescope_environment(runtime_dir)
+        if gamescope_env:
+            return gamescope_env
+
+        # Not a gamescope session — fall back to locating the desktop's own
+        # Wayland socket (or, failing that, its X11 Xauthority cookie)
         overrides = {"XDG_RUNTIME_DIR": runtime_dir}
 
         # Needed for the system tray icon to register with the desktop —
@@ -162,7 +192,30 @@ class Plugin:
                 overrides["DISPLAY"] = ":0"
                 return overrides
 
+        # Native X11 session (e.g. GNOME/KDE on Xorg instead of Wayland) —
+        # find the real socket instead of guessing ":0"
+        display = self._find_x11_display()
+        if display:
+            overrides["DISPLAY"] = display
+            xauthority = os.environ.get("XAUTHORITY") or os.path.expanduser("~/.Xauthority")
+            if os.path.isfile(xauthority):
+                overrides["XAUTHORITY"] = xauthority
+            return overrides
+
         return overrides
+
+    def _find_x11_display(self):
+        x11_dir = "/tmp/.X11-unix"
+        if not os.path.isdir(x11_dir):
+            return None
+        try:
+            entries = sorted(os.listdir(x11_dir))
+        except OSError:
+            return None
+        for entry in entries:
+            if entry.startswith("X") and entry[1:].isdigit():
+                return f":{entry[1:]}"
+        return None
 
     def _start_hydra(self, executable: str):
         import time
@@ -179,8 +232,11 @@ class Plugin:
                 if old:
                     decky.logger.info(f"[Hydra] Stripped {var}={old}")
 
-            # Ensure a display is set — Gamescope/Plasma use Wayland
-            args = [executable, "--hidden"]
+            # Ensure a display is set — Gamescope/Plasma use Wayland. Chromium's
+            # own sandbox setup is unreliable when launched outside a real
+            # interactive session (e.g. from this systemd-managed plugin), so
+            # skip it — there's no untrusted content to sandbox here anyway
+            args = [executable, "--hidden", "--no-sandbox"]
             if not env.get("DISPLAY") and not env.get("WAYLAND_DISPLAY"):
                 discovered = self._discover_display_env()
                 if discovered:
@@ -334,9 +390,14 @@ class Plugin:
         subprocess.run([BACKEND_PATH, "toggle-automatic-cloud-sync", shop, object_id, str(automatic_cloud_sync).lower()], capture_output=True, text=True, check=True)
 
     async def is_hydra_launcher_running(self):
-        temp_dir = tempfile.gettempdir()
-        lockfile = f"{temp_dir}/hydra-launcher.lock"
-        return os.path.exists(lockfile)
+        # Hydra Launcher doesn't reliably create the lockfile, so check for
+        # the actual process instead
+        try:
+            result = subprocess.run(["pgrep", "-f", "hydralauncher"], capture_output=True, timeout=5)
+            return result.returncode == 0
+        except Exception as e:
+            decky.logger.error(f"[Hydra] is_hydra_launcher_running error: {e}")
+            return False
 
     async def get_steam_emu_ini_settings(self, executable_path: str | None, title: str):
         return steam_emu.get_settings(executable_path, title)

--- a/main.py
+++ b/main.py
@@ -8,6 +8,16 @@ import steam_emu
 PLUGIN_DIR = decky.DECKY_PLUGIN_DIR
 BACKEND_PATH = f"{PLUGIN_DIR}/bin/backend"
 
+HYDRA_SHALLOW_SEARCH_TIMEOUT_S = 5
+HYDRA_DEEP_SEARCH_TIMEOUT_S = 20
+HYDRA_LOCKFILE_POLL_INTERVAL_S = 0.5
+HYDRA_LOCKFILE_POLL_ATTEMPTS = 10
+# Below this runtime, an exit counts as a crash rather than a normal quit
+HYDRA_QUICK_CRASH_WINDOW_S = 60
+# Consecutive quick crashes before we stop auto-relaunching for a while
+HYDRA_CRASH_STREAK_LIMIT = 3
+HYDRA_CRASH_BACKOFF_S = 300
+
 class Plugin:
     async def get_auth(self):
         result = subprocess.run([BACKEND_PATH, "get-auth"], capture_output=True, text=True, check=True)
@@ -87,7 +97,7 @@ class Plugin:
                     result = subprocess.run(
                         ["find", directory, "-maxdepth", "2", "-iname", "hydra.appimage",
                          "-o", "-maxdepth", "2", "-iname", "hydra"],
-                        capture_output=True, text=True, timeout=5
+                        capture_output=True, text=True, timeout=HYDRA_SHALLOW_SEARCH_TIMEOUT_S
                     )
                     for line in result.stdout.strip().splitlines():
                         path = line.strip()
@@ -98,11 +108,11 @@ class Plugin:
                     decky.logger.warning(f"[Hydra] Shallow search timed out in {directory}")
 
             # Step 3 — deep: recursive, hard cap at 20s
-            decky.logger.info("[Hydra] Starting deep search (20s timeout)…")
+            decky.logger.info(f"[Hydra] Starting deep search ({HYDRA_DEEP_SEARCH_TIMEOUT_S}s timeout)…")
             try:
                 result = subprocess.run(
                     ["find", home, "-iname", "hydra.appimage", "-o", "-iname", "hydra"],
-                    capture_output=True, text=True, timeout=20
+                    capture_output=True, text=True, timeout=HYDRA_DEEP_SEARCH_TIMEOUT_S
                 )
                 for line in result.stdout.strip().splitlines():
                     path = line.strip()
@@ -205,10 +215,10 @@ class Plugin:
 
             decky.logger.info(f"[Hydra] Process started pid={proc.pid}, log at {log_path}")
 
-            # Wait up to 5s for the lockfile to confirm Hydra actually started
+            # Wait for the lockfile to confirm Hydra actually started
             lockfile = os.path.join(tempfile.gettempdir(), "hydra-launcher.lock")
-            for _ in range(10):
-                time.sleep(0.5)
+            for _ in range(HYDRA_LOCKFILE_POLL_ATTEMPTS):
+                time.sleep(HYDRA_LOCKFILE_POLL_INTERVAL_S)
                 if os.path.exists(lockfile):
                     decky.logger.info("[Hydra] Lockfile confirmed — Hydra is running")
                     return {"success": True, "path": executable}
@@ -225,7 +235,8 @@ class Plugin:
                     pass
                 return {"success": False, "error": f"Hydra exited immediately (code {ret}). Check /tmp/hydra-decky-launch.log"}
 
-            decky.logger.warning("[Hydra] Lockfile not found after 5s but process is still running")
+            wait_total_s = HYDRA_LOCKFILE_POLL_ATTEMPTS * HYDRA_LOCKFILE_POLL_INTERVAL_S
+            decky.logger.warning(f"[Hydra] Lockfile not found after {wait_total_s}s but process is still running")
             return {"success": True, "path": executable}
 
         except Exception as e:
@@ -241,15 +252,15 @@ class Plugin:
         # A crash-looping binary (e.g. incompatible with this CPU) dies within
         # a few seconds to under a minute. A real run lasts much longer, so
         # any exit past that resets the streak instead of counting as a crash
-        if ran_for >= 60:
+        if ran_for >= HYDRA_QUICK_CRASH_WINDOW_S:
             self._hydra_crash_streak = 0
             return
 
         self._hydra_crash_streak = getattr(self, "_hydra_crash_streak", 0) + 1
         decky.logger.warning(f"[Hydra] Process exited after {ran_for:.1f}s (crash streak={self._hydra_crash_streak})")
 
-        if self._hydra_crash_streak >= 3:
-            self._hydra_backoff_until = time.time() + 300
+        if self._hydra_crash_streak >= HYDRA_CRASH_STREAK_LIMIT:
+            self._hydra_backoff_until = time.time() + HYDRA_CRASH_BACKOFF_S
             decky.logger.error("[Hydra] 3 quick crashes in a row — backing off launches for 5 minutes")
 
     async def update_game_steam_shortcut(self, shop: str, object_id: str, app_id: int):

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import subprocess
 import json
 import tempfile
 import decky
+import steam_emu
 
 PLUGIN_DIR = decky.DECKY_PLUGIN_DIR
 BACKEND_PATH = f"{PLUGIN_DIR}/bin/backend"
@@ -41,6 +42,17 @@ class Plugin:
         return result.stdout.strip() == "true"
 
     async def launch_hydra_background(self):
+        import time
+
+        backoff_until = getattr(self, "_hydra_backoff_until", 0)
+        if time.time() < backoff_until:
+            remaining = int(backoff_until - time.time())
+            decky.logger.warning(f"[Hydra] Skipping launch, backing off for {remaining}s after repeated crashes")
+            return {
+                "success": False,
+                "error": f"Hydra keeps crashing right after starting on this machine. Not retrying for {remaining}s — try updating Hydra Launcher.",
+            }
+
         home = os.path.expanduser("~")
         decky.logger.info(f"[Hydra] Searching for executable, home={home}")
 
@@ -107,8 +119,45 @@ class Plugin:
             decky.logger.error(f"[Hydra] launch_hydra_background unexpected error: {e}")
             return {"success": False, "error": str(e)}
 
+    def _discover_display_env(self):
+        """Find the desktop session's real Wayland socket (or, failing that,
+        its X11 Xauthority cookie). plugin_loader.service runs with no display
+        env at all, so blindly forcing DISPLAY=:0 fails with "Authorization
+        required, but no authorization protocol specified"."""
+        runtime_dir = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
+        if not os.path.isdir(runtime_dir):
+            return {}
+
+        overrides = {"XDG_RUNTIME_DIR": runtime_dir}
+
+        # Needed for the system tray icon to register with the desktop —
+        # without it Hydra runs fine but shows up nowhere
+        bus_path = os.path.join(runtime_dir, "bus")
+        if os.path.exists(bus_path):
+            overrides["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path={bus_path}"
+
+        try:
+            entries = sorted(os.listdir(runtime_dir))
+        except Exception as e:
+            decky.logger.error(f"[Hydra] Failed to list {runtime_dir}: {e}")
+            return overrides
+
+        for entry in entries:
+            if entry.startswith("wayland-") and not entry.endswith(".lock"):
+                overrides["WAYLAND_DISPLAY"] = entry
+                return overrides
+
+        for entry in entries:
+            if entry.startswith("xauth_"):
+                overrides["XAUTHORITY"] = os.path.join(runtime_dir, entry)
+                overrides["DISPLAY"] = ":0"
+                return overrides
+
+        return overrides
+
     def _start_hydra(self, executable: str):
         import time
+        import threading
 
         log_path = "/tmp/hydra-decky-launch.log"
         try:
@@ -121,21 +170,38 @@ class Plugin:
                 if old:
                     decky.logger.info(f"[Hydra] Stripped {var}={old}")
 
-            # Ensure a display is set — Gamescope uses Wayland
+            # Ensure a display is set — Gamescope/Plasma use Wayland
+            args = [executable, "--hidden"]
             if not env.get("DISPLAY") and not env.get("WAYLAND_DISPLAY"):
-                env["DISPLAY"] = ":0"
-                decky.logger.warning("[Hydra] No display env found, forcing DISPLAY=:0")
+                discovered = self._discover_display_env()
+                if discovered:
+                    env.update(discovered)
+                    decky.logger.info(f"[Hydra] Discovered display env: {discovered}")
+                    if discovered.get("WAYLAND_DISPLAY"):
+                        # Electron doesn't auto-switch off X11 just because
+                        # WAYLAND_DISPLAY is set — it needs this explicitly,
+                        # otherwise it fails with "Missing X server or $DISPLAY"
+                        args.append("--ozone-platform=wayland")
+                else:
+                    env["DISPLAY"] = ":0"
+                    decky.logger.warning("[Hydra] No display env found, forcing DISPLAY=:0")
 
             decky.logger.info(f"[Hydra] DISPLAY={env.get('DISPLAY')} WAYLAND_DISPLAY={env.get('WAYLAND_DISPLAY')}")
 
             with open(log_path, "w") as log_file:
                 proc = subprocess.Popen(
-                    [executable, "--hidden"],
+                    args,
                     stdout=log_file,
                     stderr=log_file,
                     start_new_session=True,
                     env=env,
                 )
+
+            # Reap the child whenever it exits, however long that takes, so it
+            # doesn't linger as a zombie under this plugin's process. Also
+            # tracks quick crashes (e.g. a binary incompatible with this CPU)
+            # so we stop hammering relaunches once they clearly aren't working
+            threading.Thread(target=self._on_hydra_exit, args=(proc, time.time()), daemon=True).start()
 
             decky.logger.info(f"[Hydra] Process started pid={proc.pid}, log at {log_path}")
 
@@ -165,6 +231,26 @@ class Plugin:
         except Exception as e:
             decky.logger.error(f"[Hydra] Failed to start {executable}: {e}")
             return {"success": False, "error": f"Failed to start: {e}"}
+
+    def _on_hydra_exit(self, proc, started_at):
+        import time
+
+        proc.wait()
+        ran_for = time.time() - started_at
+
+        # A crash-looping binary (e.g. incompatible with this CPU) dies within
+        # a few seconds to under a minute. A real run lasts much longer, so
+        # any exit past that resets the streak instead of counting as a crash
+        if ran_for >= 60:
+            self._hydra_crash_streak = 0
+            return
+
+        self._hydra_crash_streak = getattr(self, "_hydra_crash_streak", 0) + 1
+        decky.logger.warning(f"[Hydra] Process exited after {ran_for:.1f}s (crash streak={self._hydra_crash_streak})")
+
+        if self._hydra_crash_streak >= 3:
+            self._hydra_backoff_until = time.time() + 300
+            decky.logger.error("[Hydra] 3 quick crashes in a row — backing off launches for 5 minutes")
 
     async def update_game_steam_shortcut(self, shop: str, object_id: str, app_id: int):
         try:
@@ -241,3 +327,9 @@ class Plugin:
         temp_dir = tempfile.gettempdir()
         lockfile = f"{temp_dir}/hydra-launcher.lock"
         return os.path.exists(lockfile)
+
+    async def get_steam_emu_ini_settings(self, executable_path: str | None, title: str):
+        return steam_emu.get_settings(executable_path, title)
+
+    async def set_steam_emu_ini_settings(self, ini_path: str, user_name: str, language: str):
+        return steam_emu.set_settings(ini_path, user_name, language)

--- a/main.py
+++ b/main.py
@@ -67,14 +67,14 @@ class Plugin:
         decky.logger.info(f"[Hydra] Searching for executable, home={home}")
 
         try:
-            # Step 1 — fast: known fixed paths (no filesystem scan)
+            # Step 1 — fast: known fixed paths (no filesystem scan). Hydra
+            # Launcher is only ever distributed as an AppImage, so we don't
+            # guess at a bare "hydra" binary in system dirs — that name
+            # collides with unrelated tools (e.g. THC-Hydra installs its
+            # binary at exactly /usr/bin/hydra)
             fast_candidates = [
                 f"{home}/AppImages/hydra.AppImage",
                 f"{home}/Applications/hydra.AppImage",
-                f"{home}/.local/bin/hydra",
-                "/usr/bin/hydra",
-                "/usr/local/bin/hydra",
-                "/opt/hydra/hydra",
             ]
             for path in fast_candidates:
                 if os.path.isfile(path) and os.access(path, os.X_OK):
@@ -95,8 +95,7 @@ class Plugin:
                     continue
                 try:
                     result = subprocess.run(
-                        ["find", directory, "-maxdepth", "2", "-iname", "hydra.appimage",
-                         "-o", "-maxdepth", "2", "-iname", "hydra"],
+                        ["find", directory, "-maxdepth", "2", "-iname", "hydra.appimage"],
                         capture_output=True, text=True, timeout=HYDRA_SHALLOW_SEARCH_TIMEOUT_S
                     )
                     for line in result.stdout.strip().splitlines():
@@ -111,7 +110,7 @@ class Plugin:
             decky.logger.info(f"[Hydra] Starting deep search ({HYDRA_DEEP_SEARCH_TIMEOUT_S}s timeout)…")
             try:
                 result = subprocess.run(
-                    ["find", home, "-iname", "hydra.appimage", "-o", "-iname", "hydra"],
+                    ["find", home, "-iname", "hydra.appimage"],
                     capture_output=True, text=True, timeout=HYDRA_DEEP_SEARCH_TIMEOUT_S
                 )
                 for line in result.stdout.strip().splitlines():

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# package.sh — build the frontend and zip the plugin into a uniquely,
+# incrementally named archive under packages/, ready for Decky Loader's
+# "Install Plugin from ZIP". Never overwrites a previous zip: each run
+# produces packages/decky-hydra-launcher-1.zip, -2.zip, -3.zip, ...
+#
+# Note: this does NOT compile the Rust backend (backend/), it only packages
+# whatever is already at bin/backend (if present). Features that shell out to
+# the backend binary won't work in a zip built this way unless bin/backend
+# was built separately (e.g. via the Decky CLI + Docker, or copied from an
+# existing install).
+#
+#   ./package.sh
+#
+set -euo pipefail
+
+log()  { printf '\e[1;35m[package]\e[0m %s\n' "$*"; }
+die()  { printf '\e[1;31m[fail]\e[0m %s\n' "$*" >&2; exit 1; }
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAME="$(basename "$PLUGIN_DIR")"       # decky-hydra-launcher
+REPO_ROOT="$(dirname "$PLUGIN_DIR")"
+OUT_DIR="$PLUGIN_DIR/packages"
+
+command -v pnpm >/dev/null || die "pnpm not found"
+command -v zip >/dev/null || die "zip not found"
+
+log "Building frontend..."
+( cd "$PLUGIN_DIR" && pnpm run build )
+
+mkdir -p "$OUT_DIR"
+n=1
+while [[ -e "$OUT_DIR/${NAME}-$n.zip" ]]; do
+  n=$((n + 1))
+done
+OUT="$OUT_DIR/${NAME}-$n.zip"
+
+log "Zipping -> packages/$(basename "$OUT")"
+cd "$REPO_ROOT"
+zip -r -q "$OUT" "$NAME" \
+  -x "$NAME/node_modules/*" \
+  -x "$NAME/src/*" \
+  -x "$NAME/packages/*" \
+  -x "$NAME/backend/*" \
+  -x "$NAME/proto/*" \
+  -x "$NAME/cli/*" \
+  -x "$NAME/out/*" \
+  -x "$NAME/.vscode/*" \
+  -x "$NAME/.github/*" \
+  -x "$NAME/.claude/*" \
+  -x "$NAME/.git/*" \
+  -x "$NAME/.gitignore" \
+  -x "$NAME/.gitmodules" \
+  -x "$NAME/decky.pyi" \
+  -x "$NAME/tsconfig.json" \
+  -x "$NAME/eslint.config.js" \
+  -x "$NAME/rollup.config.js" \
+  -x "$NAME/README.md" \
+  -x "$NAME/LICENSE" \
+  -x "$NAME/thumb.gif" \
+  -x "$NAME/pnpm-lock.yaml" \
+  -x "$NAME/package.sh" \
+  -x '*/__pycache__/*' \
+  -x '*.pyc' \
+  -x '*.DS_Store'
+
+log "Done: $OUT"

--- a/py_modules/steam_emu.py
+++ b/py_modules/steam_emu.py
@@ -1,0 +1,137 @@
+import os
+from pathlib import Path
+import decky
+
+USERNAME_KEY = "UserName="
+LANGUAGE_KEY = "Language="
+
+
+def find_ini(executable_path: str):
+    if not executable_path:
+        return None
+    directory = os.path.dirname(executable_path)
+    if not os.path.isdir(directory):
+        return None
+    try:
+        for entry in os.listdir(directory):
+            if entry.lower() == "steam_emu.ini":
+                return os.path.join(directory, entry)
+    except Exception as e:
+        decky.logger.error(f"[Hydra] Failed to list {directory}: {e}")
+    return None
+
+
+def _iter_steam_shortcuts():
+    """Yield (appname, exe) for every non-Steam shortcut, across all Steam users.
+
+    Games launched through Proton don't get their executablePath backfilled in
+    the Hydra database, so this is the only reliable way to locate their
+    install directory (Steam's shortcuts.vdf already has the resolved path).
+    """
+    userdata = Path(decky.DECKY_USER_HOME) / ".local" / "share" / "Steam" / "userdata"
+    if not userdata.is_dir():
+        return
+    for user_dir in userdata.iterdir():
+        if not user_dir.is_dir() or not user_dir.name.isdigit():
+            continue
+        shortcuts_path = user_dir / "config" / "shortcuts.vdf"
+        if not shortcuts_path.is_file():
+            continue
+        try:
+            data = shortcuts_path.read_bytes()
+        except Exception as e:
+            decky.logger.error(f"[Hydra] Failed to read shortcuts.vdf: {e}")
+            continue
+
+        appname = None
+        i = 0
+        while i < len(data):
+            if data[i] != 0x01:
+                i += 1
+                continue
+            j = i + 1
+            while j < len(data) and data[j] != 0:
+                j += 1
+            key = data[i + 1:j].decode("utf-8", errors="ignore").lower()
+            start = j + 1
+            end = data.find(b"\x00", start)
+            if end == -1:
+                break
+            value = data[start:end].decode("utf-8", errors="ignore").strip('"')
+            if key == "appname":
+                appname = value
+            elif key == "exe" and appname:
+                yield appname, value
+                appname = None
+            i = end + 1
+
+
+def find_ini_by_title(title: str):
+    if not title:
+        return None
+    for appname, exe in _iter_steam_shortcuts():
+        if appname.strip().lower() == title.strip().lower():
+            ini_path = find_ini(exe)
+            if ini_path:
+                return ini_path
+    return None
+
+
+def get_settings(executable_path: str, title: str):
+    ini_path = find_ini(executable_path) or find_ini_by_title(title)
+    if not ini_path:
+        return None
+
+    try:
+        with open(ini_path, "r", encoding="utf-8", errors="ignore") as f:
+            lines = f.readlines()
+    except Exception as e:
+        decky.logger.error(f"[Hydra] Failed to read {ini_path}: {e}")
+        return None
+
+    section = None
+    user_name = None
+    language = None
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped[1:-1]
+        elif section == "Settings" and stripped.startswith(USERNAME_KEY):
+            user_name = stripped[len(USERNAME_KEY):]
+        elif section == "Settings" and stripped.startswith(LANGUAGE_KEY):
+            language = stripped[len(LANGUAGE_KEY):]
+
+    # steam_emu.ini always has both keys, but bail out if the file doesn't
+    # actually match the expected format rather than returning empty values
+    if user_name is None and language is None:
+        return None
+
+    return {"iniPath": ini_path, "userName": user_name or "", "language": language or ""}
+
+
+def set_settings(ini_path: str, user_name: str, language: str):
+    try:
+        with open(ini_path, "r", encoding="utf-8", errors="ignore") as f:
+            lines = f.readlines()
+
+        section = None
+        updated_lines = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("[") and stripped.endswith("]"):
+                section = stripped[1:-1]
+                updated_lines.append(line)
+            elif section == "Settings" and stripped.startswith(USERNAME_KEY):
+                updated_lines.append(f"{USERNAME_KEY}{user_name}\n")
+            elif section == "Settings" and stripped.startswith(LANGUAGE_KEY):
+                updated_lines.append(f"{LANGUAGE_KEY}{language}\n")
+            else:
+                updated_lines.append(line)
+
+        with open(ini_path, "w", encoding="utf-8") as f:
+            f.writelines(updated_lines)
+
+        return {"success": True}
+    except Exception as e:
+        decky.logger.error(f"[Hydra] set_steam_emu_ini_settings error: {e}")
+        return {"success": False, "error": str(e)}

--- a/py_modules/steam_emu.py
+++ b/py_modules/steam_emu.py
@@ -145,6 +145,8 @@ def set_settings(ini_path: str, user_name: str, language: str):
             missing_lines.append(f"{LANGUAGE_KEY}{language}\n")
         if missing_lines:
             insert_at = settings_insert_at if settings_insert_at is not None else len(updated_lines)
+            if insert_at > 0 and not updated_lines[insert_at - 1].endswith("\n"):
+                updated_lines[insert_at - 1] += "\n"
             updated_lines[insert_at:insert_at] = missing_lines
 
         with open(ini_path, "w", encoding="utf-8") as f:

--- a/py_modules/steam_emu.py
+++ b/py_modules/steam_emu.py
@@ -115,18 +115,37 @@ def set_settings(ini_path: str, user_name: str, language: str):
             lines = f.readlines()
 
         section = None
+        found_username = False
+        found_language = False
+        settings_insert_at = None
         updated_lines = []
         for line in lines:
             stripped = line.strip()
             if stripped.startswith("[") and stripped.endswith("]"):
+                if section == "Settings" and settings_insert_at is None:
+                    settings_insert_at = len(updated_lines)
                 section = stripped[1:-1]
                 updated_lines.append(line)
             elif section == "Settings" and stripped.startswith(USERNAME_KEY):
                 updated_lines.append(f"{USERNAME_KEY}{user_name}\n")
+                found_username = True
             elif section == "Settings" and stripped.startswith(LANGUAGE_KEY):
                 updated_lines.append(f"{LANGUAGE_KEY}{language}\n")
+                found_language = True
             else:
                 updated_lines.append(line)
+
+        # A key may be present in the file but blank (get_settings still
+        # surfaces it), so insert whichever one is actually missing instead
+        # of silently dropping it
+        missing_lines = []
+        if not found_username:
+            missing_lines.append(f"{USERNAME_KEY}{user_name}\n")
+        if not found_language:
+            missing_lines.append(f"{LANGUAGE_KEY}{language}\n")
+        if missing_lines:
+            insert_at = settings_insert_at if settings_insert_at is not None else len(updated_lines)
+            updated_lines[insert_at:insert_at] = missing_lines
 
         with open(ini_path, "w", encoding="utf-8") as f:
             f.writelines(updated_lines)

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -34,6 +34,29 @@ export interface Game {
   shop: "steam";
   winePrefixPath: string | null;
   automaticCloudSync: boolean;
+  executablePath: string | null;
+}
+
+export type DownloadStatus =
+  | "active"
+  | "waiting"
+  | "paused"
+  | "error"
+  | "complete"
+  | "seeding"
+  | "extracting";
+
+export interface Download {
+  shop: string;
+  objectId: string;
+  folderName: string | null;
+  progress: number;
+  bytesDownloaded: number;
+  fileSize: number | null;
+  status: DownloadStatus | null;
+  extracting: boolean;
+  extractionProgress: number;
+  queued: boolean;
 }
 
 export interface User {

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -34,6 +34,7 @@ export interface Game {
   shop: "steam";
   winePrefixPath: string | null;
   automaticCloudSync: boolean;
+  executablePath?: string | null;
 }
 
 export interface User {

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -37,6 +37,12 @@ export interface Game {
   executablePath: string | null;
 }
 
+export interface SteamEmuIniSettings {
+  iniPath: string;
+  userName: string;
+  language: string;
+}
+
 export type DownloadStatus =
   | "active"
   | "waiting"

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -1,0 +1,15 @@
+import { DialogButton, type DialogButtonProps } from "@decky/ui";
+
+export function Button({ className, ...props }: DialogButtonProps) {
+  return (
+    <>
+      <style>{`
+        .hydra-btn:focus,
+        .hydra-btn:hover {
+          border: 2px solid #fff !important;
+        }
+      `}</style>
+      <DialogButton {...props} className={`hydra-btn${className ? ` ${className}` : ""}`} />
+    </>
+  );
+}

--- a/src/components/download-item.tsx
+++ b/src/components/download-item.tsx
@@ -1,0 +1,69 @@
+import { Focusable, PanelSectionRow } from "@decky/ui";
+import { FaPlus, FaTrash } from "react-icons/fa6";
+import { GameIcon } from "./game-icon";
+import { Button } from "./button";
+import { formatBytes } from "../helpers";
+import type { Download } from "../api-types";
+
+interface DownloadItemProps {
+  download: Download;
+  title: string;
+  iconUrl?: string | null;
+  executablePath?: string | null;
+  speed?: number;
+  onDismiss?: () => void;
+  onAddToSteam?: () => void;
+}
+
+export function DownloadItem({ download: d, title, iconUrl, executablePath, speed, onDismiss, onAddToSteam }: DownloadItemProps) {
+  const progress = d.extracting ? d.extractionProgress : d.progress;
+
+  const statusLabel = d.status === "complete"
+    ? "Complete"
+    : d.extracting
+      ? `Extracting… ${Math.round(d.extractionProgress * 100)}%`
+      : d.status === "active"
+        ? `${Math.round(progress * 100)}% · ${formatBytes(d.bytesDownloaded)}${d.fileSize ? ` / ${formatBytes(d.fileSize)}` : ""}${speed ? ` · ${formatBytes(speed)}/s` : ""}`
+        : d.status === "waiting"
+          ? "Waiting…"
+          : d.status === "paused"
+            ? "Paused"
+            : d.status === "error"
+              ? "Error"
+              : "";
+
+  const showAddToSteam = d.status === "complete" && !!executablePath && !!onAddToSteam;
+  const showDismiss = !!onDismiss;
+
+  return (
+    <PanelSectionRow key={d.objectId}>
+      <div className="download-item">
+        <div className="download-item__header">
+          <GameIcon src={iconUrl} alt={title} size={30} />
+          <span className="download-item__title">{title}</span>
+          {(showAddToSteam || showDismiss) && (
+            <Focusable className="download-item__actions" flow-children="horizontal">
+              {showAddToSteam && (
+                <Button style={{ minWidth: "unset", width: 28, height: 28, padding: 0, display: "flex", alignItems: "center", justifyContent: "center" }} onClick={onAddToSteam} title="Add to Steam">
+                  <FaPlus size={12} />
+                </Button>
+              )}
+              {showDismiss && (
+                <Button style={{ minWidth: "unset", width: 28, height: 28, padding: 0, display: "flex", alignItems: "center", justifyContent: "center" }} onClick={onDismiss}>
+                  <FaTrash size={12} />
+                </Button>
+              )}
+            </Focusable>
+          )}
+        </div>
+        <div className="download-item__progress-bar">
+          <div
+            className="download-item__progress-fill"
+            style={{ width: `${Math.round(progress * 100)}%` }}
+          />
+        </div>
+        <span className="download-item__status">{statusLabel}</span>
+      </div>
+    </PanelSectionRow>
+  );
+}

--- a/src/components/downloads-section.tsx
+++ b/src/components/downloads-section.tsx
@@ -3,7 +3,7 @@ import { toaster } from "@decky/api";
 import { useEffect, useRef, useState } from "react";
 import { useLibraryStore } from "../stores";
 import { api } from "../hydra-api";
-import { getDownloads, dismissDownload, getSteamShortcutExePaths } from "../events";
+import { getDownloads, dismissDownload, getSteamShortcutExePaths, updateGameSteamShortcut } from "../events";
 import type { Download, GameAssets, Game } from "../api-types";
 import { DownloadItem } from "./download-item";
 
@@ -116,6 +116,8 @@ export function DownloadsSection() {
     }
 
     setSteamShortcutPaths((prev) => new Set([...prev, executablePath]));
+
+    updateGameSteamShortcut(d.shop, d.objectId, appId).catch(() => {});
 
     if (assets && appId) {
       const artworkPairs: [string | null | undefined, number][] = [

--- a/src/components/downloads-section.tsx
+++ b/src/components/downloads-section.tsx
@@ -1,0 +1,178 @@
+import { PanelSection, PanelSectionRow } from "@decky/ui";
+import { toaster } from "@decky/api";
+import { useEffect, useRef, useState } from "react";
+import { useLibraryStore } from "../stores";
+import { api } from "../hydra-api";
+import { getDownloads, dismissDownload, getSteamShortcutExePaths } from "../events";
+import type { Download, GameAssets, Game } from "../api-types";
+import { DownloadItem } from "./download-item";
+
+const POLL_INTERVAL_S = 3;
+
+async function imageUrlToBase64(url: string): Promise<{ base64: string; ext: "png" | "jpg" } | null> {
+  try {
+    const resp = await fetch(url);
+    const blob = await resp.blob();
+    const ext: "png" | "jpg" = blob.type === "image/png" ? "png" : "jpg";
+    const base64 = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve((reader.result as string).split(",")[1]);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+    return { base64, ext };
+  } catch {
+    return null;
+  }
+}
+
+function resolveGameTitle(download: Download, library: Pick<Game, "objectId" | "title">[]): string {
+  return library.find((g) => g.objectId === download.objectId)?.title
+    ?? download.folderName
+    ?? download.objectId;
+}
+
+export function DownloadsSection() {
+  const { library } = useLibraryStore();
+
+  const [steamShortcutPaths, setSteamShortcutPaths] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [activeDownloads, setActiveDownloads] = useState<Download[]>([]);
+  const [completedDownloads, setCompletedDownloads] = useState<Download[]>([]);
+  const [speeds, setSpeeds] = useState<Map<string, number>>(new Map());
+
+  const prevStatuses = useRef<Map<string, string | null>>(new Map());
+  const prevBytes = useRef<Map<string, number>>(new Map());
+  const isFirstPoll = useRef(true);
+
+  useEffect(() => {
+    getSteamShortcutExePaths()
+      .then((paths) => setSteamShortcutPaths(new Set(paths)))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const poll = async () => {
+      try {
+        const downloads = await getDownloads();
+
+        if (!isFirstPoll.current) {
+          const { library: currentLibrary } = useLibraryStore.getState();
+          for (const d of downloads) {
+            const prev = prevStatuses.current.get(d.objectId);
+            if (d.status === "complete" && prev !== null && prev !== "complete") {
+              toaster.toast({ title: "Download complete", body: resolveGameTitle(d, currentLibrary) });
+            }
+          }
+        }
+
+        const newSpeeds = new Map<string, number>();
+        for (const d of downloads) {
+          const prev = prevBytes.current.get(d.objectId);
+          if (prev !== undefined && d.status === "active") {
+            newSpeeds.set(d.objectId, Math.max(0, d.bytesDownloaded - prev) / POLL_INTERVAL_S);
+          }
+          prevBytes.current.set(d.objectId, d.bytesDownloaded);
+        }
+        setSpeeds(newSpeeds);
+
+        isFirstPoll.current = false;
+        setLoading(false);
+        prevStatuses.current = new Map(downloads.map((d) => [d.objectId, d.status ?? null]));
+
+        setActiveDownloads(
+          downloads.filter((d) => d.status === "active" || d.status === "waiting" || d.status === "paused" || d.status === "error" || d.extracting)
+        );
+        setCompletedDownloads(downloads.filter((d) => d.status === "complete"));
+      } catch (_) {}
+    };
+
+    poll();
+    const interval = setInterval(poll, POLL_INTERVAL_S * 1_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleDismiss = async (download: Download) => {
+    setCompletedDownloads((prev) => prev.filter((d) => d.objectId !== download.objectId));
+    try {
+      const result = await dismissDownload(download.shop, download.objectId);
+      if (!result.success) {
+        setCompletedDownloads((prev) => [...prev, download]);
+        toaster.toast({ title: "Hydra", body: result.error ?? "Could not delete — close Hydra desktop first" });
+      }
+    } catch {
+      setCompletedDownloads((prev) => [...prev, download]);
+    }
+  };
+
+  const handleAddToSteam = async (d: Download, executablePath: string, title: string) => {
+    const [appId, assets] = await Promise.all([
+      SteamClient.Apps.AddShortcut(title, executablePath, "", "") as Promise<number>,
+      api.get<GameAssets | null>(`games/steam/${d.objectId}`).json().catch(() => null),
+    ]);
+
+    if (assets?.title && appId) {
+      SteamClient.Apps.SetShortcutName(appId, assets.title);
+    }
+
+    setSteamShortcutPaths((prev) => new Set([...prev, executablePath]));
+
+    if (assets && appId) {
+      const artworkPairs: [string | null | undefined, number][] = [
+        [assets.coverImageUrl, 0],
+        [assets.libraryHeroImageUrl, 1],
+        [assets.logoImageUrl, 2],
+        [assets.libraryImageUrl, 3],
+      ];
+      for (const [url, assetType] of artworkPairs) {
+        if (!url) continue;
+        const result = await imageUrlToBase64(url);
+        if (result) {
+          await SteamClient.Apps.SetCustomArtworkForApp(appId, result.base64, result.ext, assetType).catch(() => {});
+        }
+      }
+    }
+  };
+
+  return (
+    <PanelSection title="Downloads">
+      {loading ? (
+        <PanelSectionRow>
+          <span className="downloads-placeholder">Loading downloads…</span>
+        </PanelSectionRow>
+      ) : activeDownloads.length === 0 && completedDownloads.length === 0 ? (
+        <PanelSectionRow>
+          <span className="downloads-placeholder">No downloads</span>
+        </PanelSectionRow>
+      ) : (
+        <div className="download-list">
+          {activeDownloads.map((d) => (
+            <DownloadItem
+              key={d.objectId}
+              download={d}
+              title={resolveGameTitle(d, library)}
+              iconUrl={library.find((g) => g.objectId === d.objectId)?.iconUrl}
+              speed={speeds.get(d.objectId)}
+            />
+          ))}
+          {completedDownloads.map((d) => {
+            const game = library.find((g) => g.objectId === d.objectId);
+            const executablePath = game?.executablePath ?? null;
+            const alreadyInSteam = executablePath ? steamShortcutPaths.has(executablePath) : false;
+            return (
+              <DownloadItem
+                key={d.objectId}
+                download={d}
+                title={resolveGameTitle(d, library)}
+                iconUrl={game?.iconUrl}
+                executablePath={alreadyInSteam ? null : executablePath}
+                onDismiss={() => handleDismiss(d)}
+                onAddToSteam={executablePath ? () => handleAddToSteam(d, executablePath, resolveGameTitle(d, library)) : undefined}
+              />
+            );
+          })}
+        </div>
+      )}
+    </PanelSection>
+  );
+}

--- a/src/components/game-icon.tsx
+++ b/src/components/game-icon.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+
+interface GameIconProps {
+  src: string | null | undefined;
+  alt?: string;
+  size?: number;
+}
+
+export function GameIcon({ src, alt = "", size = 30 }: GameIconProps) {
+  const [failed, setFailed] = useState(false);
+
+  if (!src || failed) {
+    return (
+      <div
+        className="game-icon-placeholder"
+        style={{ width: size, height: size, borderRadius: 8, flexShrink: 0 }}
+        title={alt}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          width={size * 0.55}
+          height={size * 0.55}
+        >
+          <rect x="3" y="3" width="18" height="18" rx="2" />
+          <path d="M3 9l4-4 4 4 4-4 4 4" />
+          <circle cx="8.5" cy="14.5" r="1.5" />
+        </svg>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      width={size}
+      height={size}
+      style={{ borderRadius: 8, objectFit: "cover", flexShrink: 0 }}
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,7 @@
 export * from "./hydra-logo";
 export * from "./cloud-icon";
 export * from "./check-icon";
+export * from "./game-icon";
+export * from "./download-item";
+export * from "./downloads-section";
+export * from "./button";

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,12 +1,19 @@
 import { callable } from "@decky/api";
-import type { Game, Auth } from "./api-types";
+import type { Game, Auth, Download } from "./api-types";
 
 export const getAuth = callable<[], Auth>("get_auth");
 export const getLibrary = callable<[], Game[]>("get_library");
+export const getDownloads = callable<[], Download[]>("get_downloads");
 export const backupAndUpload = callable<
   [string, string | null, string, string],
   void
 >("backup_and_upload");
+export const dismissDownload = callable<[string, string], { success: boolean; error?: string }>("dismiss_download");
+export const launchHydraBackground = callable<
+  [],
+  { success: boolean; path?: string; error?: string }
+>("launch_hydra_background");
+export const getSteamShortcutExePaths = callable<[], string[]>("get_steam_shortcut_exe_paths");
 export const isHydraLauncherRunning = callable<[], boolean>(
   "is_hydra_launcher_running"
 );

--- a/src/events.ts
+++ b/src/events.ts
@@ -17,3 +17,6 @@ export const downloadGameArtifact = callable<
 export const checkIfLudusaviBinaryExists = callable<[], boolean>(
   "check_if_ludusavi_binary_exists"
 );
+export const toggleAutomaticCloudSync = callable<[string, string, boolean], void>(
+  "toggle_automatic_cloud_sync"
+);

--- a/src/events.ts
+++ b/src/events.ts
@@ -14,6 +14,7 @@ export const launchHydraBackground = callable<
   { success: boolean; path?: string; error?: string }
 >("launch_hydra_background");
 export const getSteamShortcutExePaths = callable<[], string[]>("get_steam_shortcut_exe_paths");
+export const updateGameSteamShortcut = callable<[string, string, number], { success: boolean; error?: string }>("update_game_steam_shortcut");
 export const isHydraLauncherRunning = callable<[], boolean>(
   "is_hydra_launcher_running"
 );

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,5 +1,5 @@
 import { callable } from "@decky/api";
-import type { Game, Auth, Download } from "./api-types";
+import type { Game, Auth, Download, SteamEmuIniSettings } from "./api-types";
 
 export const getAuth = callable<[], Auth>("get_auth");
 export const getLibrary = callable<[], Game[]>("get_library");
@@ -28,3 +28,11 @@ export const checkIfLudusaviBinaryExists = callable<[], boolean>(
 export const toggleAutomaticCloudSync = callable<[string, string, boolean], void>(
   "toggle_automatic_cloud_sync"
 );
+export const getSteamEmuIniSettings = callable<
+  [string | null, string],
+  SteamEmuIniSettings | null
+>("get_steam_emu_ini_settings");
+export const setSteamEmuIniSettings = callable<
+  [string, string, string],
+  { success: boolean; error?: string }
+>("set_steam_emu_ini_settings");

--- a/src/game-cloud-saves.tsx
+++ b/src/game-cloud-saves.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { api } from "./hydra-api";
 import { toaster } from "@decky/api";
-import { Button, PanelSection, Spinner } from "@decky/ui";
+import { Button, PanelSection, Spinner, ToggleField } from "@decky/ui";
 import { composeToastLogo } from "./helpers";
 import { useAuthStore, useCurrentGame, useUserStore } from "./stores";
-import { backupAndUpload } from "./events";
+import { backupAndUpload, toggleAutomaticCloudSync } from "./events";
 import { CheckIcon, CloudIcon } from "./components";
 import { useDate } from "./hooks";
 import { GameCloudSave } from "./game-cloud-save";
@@ -17,6 +17,7 @@ export interface GameCloudSavesProps {
 export function GameCloudSaves({ game }: GameCloudSavesProps) {
   const [isCreatingBackup, setIsCreatingBackup] = useState(false);
   const [artifacts, setArtifacts] = useState<GameArtifact[]>([]);
+  const [automaticCloudSync, setAutomaticCloudSync] = useState(game.automaticCloudSync);
 
   const { auth } = useAuthStore();
   const { user, hasActiveSubscription } = useUserStore();
@@ -40,8 +41,17 @@ export function GameCloudSaves({ game }: GameCloudSavesProps) {
     getArtifacts();
   }, [getArtifacts]);
 
+  const handleToggleCloudSync = useCallback(async (value: boolean) => {
+    try {
+      await toggleAutomaticCloudSync(game.shop, game.objectId, value);
+      setAutomaticCloudSync(value);
+    } catch (error: unknown) {
+      console.error(error);
+    }
+  }, [game.shop, game.objectId]);
+
   const createNewBackup = useCallback(async () => {
-    if (game.automaticCloudSync && auth && hasActiveSubscription) {
+    if (automaticCloudSync && auth && hasActiveSubscription) {
       setIsCreatingBackup(true);
 
       try {
@@ -72,7 +82,7 @@ export function GameCloudSaves({ game }: GameCloudSavesProps) {
     }
   }, [
     auth,
-    game.automaticCloudSync,
+    automaticCloudSync,
     game.objectId,
     game.winePrefixPath,
     hasActiveSubscription,
@@ -99,7 +109,7 @@ export function GameCloudSaves({ game }: GameCloudSavesProps) {
               {game.title}
             </span>
 
-            {game.automaticCloudSync && (
+            {automaticCloudSync && (
               <div className="game-cloud-saves__automatic-backups">
                 <CheckIcon />
 
@@ -120,6 +130,14 @@ export function GameCloudSaves({ game }: GameCloudSavesProps) {
           Press any of the backups below to replace your current save.
         </span>
       </div>
+
+      {hasActiveSubscription && game.executablePath && (
+        <ToggleField
+          label="Automatic cloud sync"
+          checked={automaticCloudSync}
+          onChange={handleToggleCloudSync}
+        />
+      )}
 
       <div className="game-cloud-saves__cloud-saves">
         <Button

--- a/src/game-page.tsx
+++ b/src/game-page.tsx
@@ -1,0 +1,16 @@
+import { GameCloudSaves } from "./game-cloud-saves";
+import { SteamEmuSettings } from "./steam-emu-settings";
+import type { Game } from "./api-types";
+
+export interface GamePageProps {
+  game: Game;
+}
+
+export function GamePage({ game }: GamePageProps) {
+  return (
+    <>
+      <GameCloudSaves game={game} />
+      <SteamEmuSettings game={game} />
+    </>
+  );
+}

--- a/src/home.tsx
+++ b/src/home.tsx
@@ -1,5 +1,6 @@
-import { Button, PanelSection, PanelSectionRow } from "@decky/ui";
-import { useCallback, useEffect, useMemo } from "react";
+import { Button, ButtonItem, PanelSection, PanelSectionRow } from "@decky/ui";
+import { toaster } from "@decky/api";
+import { useEffect, useMemo, useState } from "react";
 import {
   useCurrentGame,
   useLibraryStore,
@@ -8,33 +9,83 @@ import {
 } from "./stores";
 import { api } from "./hydra-api";
 import { usePlaytime } from "./hooks";
-import { HydraLogo } from "./components/hydra-logo";
+import { HydraLogo, GameIcon, DownloadsSection } from "./components";
+import { isHydraLauncherRunning, launchHydraBackground } from "./events";
 import type { GameAssets } from "./api-types";
+
+type LaunchState = "idle" | "searching" | "starting";
 
 export function Home() {
   const { user, hasActiveSubscription } = useUserStore();
   const { library } = useLibraryStore();
   const { hours, minutes, seconds } = usePlaytime();
-
   const { setRoute } = useNavigationStore();
+  const { objectId, gameAssets } = useCurrentGame();
 
-  const { objectId, gameAssets, setGameAssets } = useCurrentGame();
+  const [showLaunchButton, setShowLaunchButton] = useState(false);
+  const [launchState, setLaunchState] = useState<LaunchState>("idle");
 
-  const getGameCurrentlyPlaying = useCallback(async () => {
-    const asssets = await api
-      .get<GameAssets | null>(`games/steam/${objectId}`)
-      .json();
-
-    if (asssets) {
-      setGameAssets(asssets);
+  const tryLaunchHydra = async (): Promise<boolean> => {
+    setLaunchState("searching");
+    try {
+      const result = await Promise.race([
+        launchHydraBackground(),
+        new Promise<{ success: false; error: string }>((resolve) =>
+          setTimeout(() => resolve({ success: false, error: "Search timed out after 30s" }), 30_000)
+        ),
+      ]);
+      if (result.success) {
+        setLaunchState("starting");
+        setTimeout(() => setLaunchState("idle"), 3_000);
+        return true;
+      } else {
+        setLaunchState("idle");
+        return false;
+      }
+    } catch {
+      setLaunchState("idle");
+      return false;
     }
-  }, [objectId, setGameAssets]);
+  };
+
+  // Auto-launch on mount if Hydra is not running
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const running = await isHydraLauncherRunning();
+        if (running) { setShowLaunchButton(false); return; }
+        const ok = await tryLaunchHydra();
+        if (!ok) setShowLaunchButton(true);
+      } catch {
+        setShowLaunchButton(true);
+      }
+    };
+    init();
+  }, []);
+
+  // Poll hydra running state every 3s
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      try {
+        const running = await isHydraLauncherRunning();
+        if (running) setShowLaunchButton(false);
+      } catch {}
+    }, 3_000);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
-    if (objectId) {
-      getGameCurrentlyPlaying();
-    }
-  }, [objectId, getGameCurrentlyPlaying]);
+    if (!objectId) return;
+    api.get<GameAssets | null>(`games/steam/${objectId}`)
+      .json()
+      .then((assets) => { if (assets) useCurrentGame.getState().setGameAssets(assets); })
+      .catch(() => {});
+  }, [objectId]);
+
+  const handleManualLaunch = async () => {
+    const ok = await tryLaunchHydra();
+    if (!ok) toaster.toast({ title: "Hydra", body: "Could not find Hydra executable" });
+  };
 
   const playingNowContent = useMemo(() => {
     if (objectId) {
@@ -65,7 +116,6 @@ export function Home() {
         </Button>
       );
     }
-
     return (
       <div className="playtime-description">
         <span>No game session in progress.</span>
@@ -76,6 +126,13 @@ export function Home() {
       </div>
     );
   }, [gameAssets, objectId, hours, minutes, seconds]);
+
+  const launchButtonLabel =
+    launchState === "searching"
+      ? "Searching for Hydra…"
+      : launchState === "starting"
+        ? "Starting Hydra…"
+        : "Run downloads in background";
 
   return (
     <>
@@ -104,14 +161,23 @@ export function Home() {
 
       <PanelSection title="Playing now">{playingNowContent}</PanelSection>
 
+      {showLaunchButton && (
+        <PanelSection title="Hydra">
+          <ButtonItem disabled={launchState !== "idle"} onClick={handleManualLaunch}>
+            {launchButtonLabel}
+          </ButtonItem>
+        </PanelSection>
+      )}
+
+      <DownloadsSection />
+
       <PanelSection title="Playable on the Deck">
         <div className="library-games">
           {library
             .filter((game) => game.winePrefixPath)
             .map((game) => (
-              <PanelSectionRow>
+              <PanelSectionRow key={game.remoteId}>
                 <Button
-                  key={game.remoteId}
                   className="library-game"
                   onClick={() =>
                     setRoute({
@@ -122,12 +188,7 @@ export function Home() {
                     })
                   }
                 >
-                  <img
-                    src={game.iconUrl}
-                    width="30"
-                    style={{ borderRadius: 8, objectFit: "cover" }}
-                    alt={game.title}
-                  />
+                  <GameIcon src={game.iconUrl} alt={game.title} size={30} />
                   <span className="library-game__title">{game.title}</span>
                 </Button>
               </PanelSectionRow>

--- a/src/home.tsx
+++ b/src/home.tsx
@@ -22,7 +22,7 @@ export function Home() {
   const { setRoute } = useNavigationStore();
   const { objectId, gameAssets } = useCurrentGame();
 
-  const [showLaunchButton, setShowLaunchButton] = useState(false);
+  const [isRunning, setIsRunning] = useState<boolean | null>(null);
   const [launchState, setLaunchState] = useState<LaunchState>("idle");
 
   const tryLaunchHydra = async (): Promise<boolean> => {
@@ -53,11 +53,12 @@ export function Home() {
     const init = async () => {
       try {
         const running = await isHydraLauncherRunning();
-        if (running) { setShowLaunchButton(false); return; }
+        setIsRunning(running);
+        if (running) return;
         const ok = await tryLaunchHydra();
-        if (!ok) setShowLaunchButton(true);
+        setIsRunning(ok);
       } catch {
-        setShowLaunchButton(true);
+        setIsRunning(false);
       }
     };
     init();
@@ -68,7 +69,7 @@ export function Home() {
     const interval = setInterval(async () => {
       try {
         const running = await isHydraLauncherRunning();
-        if (running) setShowLaunchButton(false);
+        setIsRunning(running);
       } catch {}
     }, 3_000);
     return () => clearInterval(interval);
@@ -84,6 +85,7 @@ export function Home() {
 
   const handleManualLaunch = async () => {
     const ok = await tryLaunchHydra();
+    setIsRunning(ok);
     if (!ok) toaster.toast({ title: "Hydra", body: "Could not find Hydra executable" });
   };
 
@@ -161,13 +163,30 @@ export function Home() {
 
       <PanelSection title="Playing now">{playingNowContent}</PanelSection>
 
-      {showLaunchButton && (
-        <PanelSection title="Hydra">
-          <ButtonItem disabled={launchState !== "idle"} onClick={handleManualLaunch}>
-            {launchButtonLabel}
-          </ButtonItem>
-        </PanelSection>
-      )}
+      <PanelSection title="Hydra">
+        <PanelSectionRow>
+          <div className="home__hydra-status">
+            <span
+              className={`home__hydra-status-dot home__hydra-status-dot--${
+                isRunning === null ? "unknown" : isRunning ? "on" : "off"
+              }`}
+            />
+            {isRunning === null
+              ? "Checking Hydra status…"
+              : isRunning
+                ? "Hydra Launcher is running"
+                : "Hydra Launcher is not running"}
+          </div>
+        </PanelSectionRow>
+
+        {isRunning === false && (
+          <PanelSectionRow>
+            <ButtonItem disabled={launchState !== "idle"} onClick={handleManualLaunch}>
+              {launchButtonLabel}
+            </ButtonItem>
+          </PanelSectionRow>
+        )}
+      </PanelSection>
 
       <DownloadsSection />
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ import { api } from "./hydra-api";
 import { Home } from "./home";
 import { WSClient } from "./ws";
 import { composeToastLogo } from "./helpers";
-import { GameCloudSaves } from "./game-cloud-saves";
+import { GamePage } from "./game-page";
 import { AuthGuide } from "./auth-guide";
 import { backupAndUpload, getLibrary, isHydraLauncherRunning } from "./events";
 import { getAuth } from "./events";
@@ -45,7 +45,7 @@ function Plugin() {
       case "auth-guide":
         return <AuthGuide />;
       case "game":
-        return <GameCloudSaves game={route.params.game as Game} />;
+        return <GamePage game={route.params.game as Game} />;
       case "home":
         return <Home />;
       default:

--- a/src/steam-emu-settings.tsx
+++ b/src/steam-emu-settings.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from "react";
+import { toaster } from "@decky/api";
+import { Button, PanelSection, PanelSectionRow, Spinner, TextField } from "@decky/ui";
+import { composeToastLogo } from "./helpers";
+import { getSteamEmuIniSettings, setSteamEmuIniSettings } from "./events";
+import type { Game, SteamEmuIniSettings } from "./api-types";
+
+export interface SteamEmuSettingsProps {
+  game: Game;
+}
+
+export function SteamEmuSettings({ game }: SteamEmuSettingsProps) {
+  const [settings, setSettings] = useState<SteamEmuIniSettings | null>(null);
+  const [userName, setUserName] = useState("");
+  const [language, setLanguage] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(true);
+    setSettings(null);
+
+    getSteamEmuIniSettings(game.executablePath, game.title)
+      .then((result) => {
+        setSettings(result);
+
+        if (result) {
+          setUserName(result.userName);
+          setLanguage(result.language);
+        }
+      })
+      .finally(() => setIsLoading(false));
+  }, [game.executablePath, game.title]);
+
+  const handleDetectLanguage = useCallback(async () => {
+    try {
+      const detected = await SteamClient.Settings.GetCurrentLanguage();
+      setLanguage(detected);
+    } catch (error: unknown) {
+      console.error(error);
+    }
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!settings) return;
+
+    setIsSaving(true);
+
+    try {
+      const result = await setSteamEmuIniSettings(
+        settings.iniPath,
+        userName,
+        language
+      );
+
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+
+      toaster.toast({
+        title: "Steam emulator settings saved",
+        body: `${userName} · ${language}`,
+        logo: composeToastLogo(game.iconUrl),
+      });
+    } catch (error: unknown) {
+      console.error(error);
+
+      toaster.toast({
+        title: "Failed to save settings",
+        body: "Please check if the game files are correct",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [settings, userName, language, game.iconUrl]);
+
+  return (
+    <PanelSection title="Steam Emulator">
+      {isLoading && (
+        <PanelSectionRow>
+          <div className="steam-emu-settings__status">
+            <Spinner width={15} />
+            Looking for a steam_emu.ini file...
+          </div>
+        </PanelSectionRow>
+      )}
+
+      {!isLoading && !settings && (
+        <PanelSectionRow>
+          <span className="steam-emu-settings__status">
+            No Steam emulator detected for this game.
+          </span>
+        </PanelSectionRow>
+      )}
+
+      {!isLoading && settings && (
+        <>
+          <PanelSectionRow>
+            <TextField
+              label="Username"
+              value={userName}
+              onChange={(e) => setUserName(e.target.value)}
+            />
+          </PanelSectionRow>
+
+          <PanelSectionRow>
+            <TextField
+              label="Language"
+              value={language}
+              onChange={(e) => setLanguage(e.target.value)}
+            />
+          </PanelSectionRow>
+
+          <PanelSectionRow>
+            <Button className="steam-emu-settings__button" onClick={handleDetectLanguage}>
+              Use my Steam language
+            </Button>
+          </PanelSectionRow>
+
+          <PanelSectionRow>
+            <Button
+              className="steam-emu-settings__button"
+              onClick={handleSave}
+              disabled={isSaving}
+            >
+              {isSaving ? <Spinner width={15} /> : "Save"}
+            </Button>
+          </PanelSectionRow>
+        </>
+      )}
+    </PanelSection>
+  );
+}

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -117,6 +117,90 @@
   }
 }
 
+.game-icon-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.3);
+  flex-shrink: 0;
+}
+
+.downloads-placeholder {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.3);
+  display: block;
+  text-align: center;
+  padding: 4px 0;
+}
+
+.download-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.download-item {
+  box-sizing: border-box;
+  width: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background-color: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  padding: 8px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  &__actions {
+    display: flex !important;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+    flex-shrink: 0;
+  }
+
+
+  &__title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #fff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+    flex: 1;
+  }
+
+  &__progress-bar {
+    box-sizing: border-box;
+    width: 100%;
+    height: 4px;
+    background-color: rgba(255, 255, 255, 0.15);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  &__progress-fill {
+    height: 100%;
+    background: linear-gradient(93deg, #0cf1ca 0%, #1dcceb 50%, #134fd0 100%);
+    border-radius: 2px;
+    transition: width 0.5s ease;
+  }
+
+  &__status {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.5);
+  }
+}
+
 .library-games {
   display: flex;
   flex-direction: column;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -4,6 +4,34 @@
   }
 }
 
+.home {
+  &__hydra-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+  }
+
+  &__hydra-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+
+    &--on {
+      background-color: #4caf50;
+    }
+
+    &--off {
+      background-color: #e15554;
+    }
+
+    &--unknown {
+      background-color: rgba(255, 255, 255, 0.3);
+    }
+  }
+}
+
 .game-cover {
   display: flex;
   justify-content: center;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -326,6 +326,32 @@
   }
 }
 
+.steam-emu-settings {
+  &__status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 14px;
+  }
+
+  &__button {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    background-color: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.8);
+    padding: 8px;
+    margin-bottom: 8px;
+    border: none;
+    gap: 8px;
+
+    @include focus-outline;
+  }
+}
+
 .cloud-save {
   width: 100%;
   display: flex;


### PR DESCRIPTION
⚠️ Depends on https://github.com/hydralauncher/decky-hydra-launcher/pull/6 and [#7](https://github.com/hydralauncher/decky-hydra-launcher/pull/7) — please merge those first, this branch builds on top of them.

I was tired of having to go back to the desktop to edit a steam_emu configuration file, so I added it to this plugin, where I feel it really belongs.

Reel commit is https://github.com/hydralauncher/decky-hydra-launcher/pull/9/changes/9fd5e8804241e6e193c9d8ae3e38f0591070fd1d

<img width="1280" height="720" alt="screenshot" src="https://github.com/user-attachments/assets/198edfb6-ad1f-47df-80a1-f4338cde28b5" />


Adds a "Steam Emulator" panel on the game detail page, letting you view
and edit the `UserName` and `Language` fields of a game's `steam_emu.ini`
directly from Decky, with a button to auto-fill the language from Steam's
own client setting.

- Detects `steam_emu.ini` via the game's `executablePath`, falling back
  to a `shortcuts.vdf` lookup by title for Wine/Proton games (where
  `executablePath` isn't populated)
- Only rewrites the `UserName=`/`Language=` lines, preserving comments
  and everything else in the file
- Also fixes Hydra Launcher failing to start from the plugin (missing
  Wayland/D-Bus env on non-Steam-Deck hardware), and adds a backoff so
  repeated crashes don't get retried in a tight loop
